### PR TITLE
TER-230 Add support for platform profiles

### DIFF
--- a/src/cli/cmd/generate/cmd.go
+++ b/src/cli/cmd/generate/cmd.go
@@ -20,6 +20,7 @@ var (
 	flagPlatformDir string
 	flagOutDir      string
 	flagApps        []string
+	flagProfile     string
 )
 
 func NewCmd() *cobra.Command {
@@ -33,6 +34,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&flagPlatformDir, "platform-dir", "p", ".", "path to the directory containing the Terrarium platform template")
 	cmd.Flags().StringArrayVarP(&flagApps, "app", "a", nil, "path to the app directory or the app yaml file. can be more then one")
 	cmd.Flags().StringVarP(&flagOutDir, "output-dir", "o", "./.terrarium", "path to the directory where you want to generate the output")
+	cmd.Flags().StringVarP(&flagProfile, "configuration-profile", "c", "", "name of platform configuration profile to apply")
 
 	return cmd
 }
@@ -62,7 +64,7 @@ func cmdRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	blockCount, err := writeTF(pm.Graph, flagOutDir, apps, m)
+	blockCount, err := writeTF(pm.Graph, flagOutDir, apps, m, flagProfile)
 	if err != nil {
 		return eris.Wrapf(err, "failed to write terraform code to dir: %s", flagOutDir)
 	}

--- a/src/cli/cmd/generate/cmd_test.go
+++ b/src/cli/cmd/generate/cmd_test.go
@@ -22,15 +22,26 @@ func TestCmd(t *testing.T) {
 			ExpError: "No Apps provided. use -a flag to set apps",
 		},
 		{
-			Name:     "invalid app path",
+			Name:     "Invalid app path",
 			Args:     []string{"-a", "./invalid-path"},
 			WantErr:  true,
 			ExpError: "invalid file path: ./invalid-path",
 		},
 		{
-			Name:           "Success",
+			Name:           "Success (no profile)",
 			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium"},
 			ValidateOutput: clitesting.ValidateOutputMatch("Successfully pulled 13 of 22 terraform blocks at: ./testdata/.terrarium\n"),
+		},
+		{
+			Name:           "Success (with profile)",
+			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium", "-c", "low-cost"},
+			ValidateOutput: clitesting.ValidateOutputMatch("Successfully pulled 13 of 22 terraform blocks at: ./testdata/.terrarium\n"),
+		},
+		{
+			Name:     "Invalid profile name",
+			Args:     []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium", "-c", "Isle"},
+			WantErr:  true,
+			ExpError: "could not retrieve configuration file for platform profile 'Isle'",
 		},
 	})
 }

--- a/src/cli/cmd/query/modules/modules_test.go
+++ b/src/cli/cmd/query/modules/modules_test.go
@@ -57,7 +57,7 @@ func Test_CmdModules(t *testing.T) {
 			},
 			ValidateOutput: func(ctx context.Context, t *testing.T, cmdOpts clitesting.CmdOpts, output []byte) bool {
 				expectedOutput := "{\"modules\":[{\"id\":\"" + mockUuid1.String() + "\",\"taxonomyId\":\"00000000-0000-0000-0000-000000000000\",\"moduleName\":\"Rds\",\"source\":\"/Users/xyz/abc/tf-dir\",\"version\":\"1\",\"description\":\"\",\"inputAttributes\":[],\"namespace\":\"" + config.FarmDefault() + "\"}],\"page\":{\"size\":100,\"index\":0,\"total\":0}}"
-				return assert.Equal(t, expectedOutput, string(output))
+				return assert.JSONEq(t, expectedOutput, string(output))
 			},
 		},
 		{
@@ -79,7 +79,7 @@ func Test_CmdModules(t *testing.T) {
 			},
 			ValidateOutput: func(ctx context.Context, t *testing.T, cmdOpts clitesting.CmdOpts, output []byte) bool {
 				expectedOutput := "{\"modules\":[{\"id\":\"" + mockUuid1.String() + "\",\"taxonomyId\":\"00000000-0000-0000-0000-000000000000\",\"moduleName\":\"Rds\",\"source\":\"/Users/xyz/abc/tf-dir\",\"version\":\"1\",\"description\":\"\",\"inputAttributes\":[],\"namespace\":\"" + config.FarmDefault() + "\"}],\"page\":{\"size\":5,\"index\":0,\"total\":0}}"
-				return assert.Equal(t, expectedOutput, string(output))
+				return assert.JSONEq(t, expectedOutput, string(output))
 			},
 		},
 	}


### PR DESCRIPTION
Add 'configuration-profile' (c) flag to generate command.

Look up a *.tfvars file with matching name in the platform and copy it over to tthe target Terraform configuration
(as *.auto.tfvars that gets applied automaticaly). The command fails if a matching profile configuration file is not found. The latest profile configuration is always applied - i.e. if re-running generate command the latest
profile always takes precedence.