### PR TITLE
TER-249 fix app yaml support in generate command

### DIFF
--- a/src/cli/cmd/generate/apps.go
+++ b/src/cli/cmd/generate/apps.go
@@ -55,7 +55,7 @@ func readAppDependency(appYamlPath string) ([]byte, error) {
 	// If it's a directory, append terrarium.yaml to the path
 	if info.IsDir() {
 		appYamlPath = path.Join(appYamlPath, defaultYAMLFileName)
-	} else if !slices.Contains([]string{"yml", "yaml"}, path.Ext(appYamlPath)) {
+	} else if !slices.Contains([]string{".yml", ".yaml"}, path.Ext(appYamlPath)) {
 		// If it's a file but not a .yaml, return an error
 		return nil, eris.New("provided path is not a directory or a .yaml|.yml file")
 	}

--- a/src/cli/cmd/generate/cmd_test.go
+++ b/src/cli/cmd/generate/cmd_test.go
@@ -29,7 +29,7 @@ func TestCmd(t *testing.T) {
 		},
 		{
 			Name:           "Success (no profile)",
-			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium"},
+			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be/terrarium.yaml", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium"},
 			ValidateOutput: clitesting.ValidateOutputMatch("Successfully pulled 13 of 22 terraform blocks at: ./testdata/.terrarium\n"),
 		},
 		{


### PR DESCRIPTION
There was a bug that'd not allow yaml files in input flags even while having it documented. Reason was the extension value was inaccurately checked for `yaml` or `yml` instead of `.yaml` or `.yml`.
This change fixes the condition, and also adds unit test to assert this use-case.