### PR TITLE
TER-232 generate app env files

### DIFF
--- a/examples/platform/dev.tfvars
+++ b/examples/platform/dev.tfvars
@@ -1,0 +1,1 @@
+all_db_instance_class="t2.nano"

--- a/examples/platform/high-availability.tfvars
+++ b/examples/platform/high-availability.tfvars
@@ -1,1 +1,0 @@
-all_db_instance_class=""

--- a/examples/platform/low-cost.tfvars
+++ b/examples/platform/low-cost.tfvars
@@ -1,1 +1,0 @@
-all_db_instance_class=""

--- a/examples/platform/prod.tfvars
+++ b/examples/platform/prod.tfvars
@@ -1,0 +1,1 @@
+all_db_instance_class="t2.large"

--- a/examples/platform/readme.md
+++ b/examples/platform/readme.md
@@ -145,16 +145,36 @@ components:
 
 Run following commands in the platform directory.
 
-To generate working terraform code based on App dependencies:
-
-```sh
-terrarium generate -a ../apps/voting-be -a ../apps/voting-fe -a ../apps/voting-worker
-```
-
 To lint platform code:
 
 ```sh
 terrarium platform lint
+```
+
+To generate working terraform code based on App dependencies:
+
+```sh
+terrarium generate -c dev -a ../apps/voting-be -a ../apps/voting-fe -a ../apps/voting-worker
+```
+
+The `terrarium generate` command generates the terraform code, a `tr_gen_profile.auto.tfvars` profile and `*.env.mustache` files for each app in the destination folder (`./.terrarium`).
+
+These files looks something like this:
+
+`app_voting_be.env.mustache`
+
+```sh
+BA_LEDGERDB_HOST="{{ tr_component_postgres_host.value.ledgerdb }}"
+BA_LEDGERDB_PASSWORD="{{ tr_component_postgres_password.value.ledgerdb }}"
+BA_LEDGERDB_PORT="{{ tr_component_postgres_port.value.ledgerdb }}"
+BA_LEDGERDB_USERNAME="{{ tr_component_postgres_username.value.ledgerdb }}"
+```
+
+As you can see, the env vars personalised for the app are templated referring to a value in terraform state file.
+after provisioning infrastructure with terraform, one can render the above template by providing the terraform state file outputs to it. like this:
+
+```sh
+terraform output -json | mustache app_banking_app.env.mustache
 ```
 
 ---

--- a/go.work.sum
+++ b/go.work.sum
@@ -464,6 +464,7 @@ gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
 rsc.io/quote/v3 v3.1.0 h1:9JKUTTIUgS6kzR9mK1YuGKv6Nl+DijDNIc0ghT58FaY=

--- a/src/cli/cmd/generate/cmd.go
+++ b/src/cli/cmd/generate/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/pkg/metadata/platform"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/utils"
 	"github.com/rotisserie/eris"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +60,7 @@ func cmdRunE(cmd *cobra.Command, args []string) error {
 
 	pm, _ := platform.NewPlatformMetadata(m, existingYaml)
 
-	err = matchAppAndPlatform(pm, apps)
+	err = utils.MatchAppAndPlatform(pm, apps)
 	if err != nil {
 		return err
 	}
@@ -67,6 +68,11 @@ func cmdRunE(cmd *cobra.Command, args []string) error {
 	blockCount, err := writeTF(pm.Graph, flagOutDir, apps, m, flagProfile)
 	if err != nil {
 		return eris.Wrapf(err, "failed to write terraform code to dir: %s", flagOutDir)
+	}
+
+	err = writeAppsEnv(pm, apps)
+	if err != nil {
+		return err
 	}
 
 	cmd.Printf("Successfully pulled %d of %d terraform blocks at: %s\n", blockCount, len(pm.Graph), flagOutDir)

--- a/src/cli/cmd/generate/cmd_test.go
+++ b/src/cli/cmd/generate/cmd_test.go
@@ -34,7 +34,7 @@ func TestCmd(t *testing.T) {
 		},
 		{
 			Name:           "Success (with profile)",
-			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium", "-c", "low-cost"},
+			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium", "-c", "dev"},
 			ValidateOutput: clitesting.ValidateOutputMatch("Successfully pulled 13 of 22 terraform blocks at: ./testdata/.terrarium\n"),
 		},
 		{

--- a/src/cli/cmd/harvest/dependencies/dependencies.go
+++ b/src/cli/cmd/harvest/dependencies/dependencies.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cldcvr/terrarium/src/pkg/metadata/taxonomy"
 	"github.com/google/uuid"
 	"github.com/rotisserie/eris"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // processYAMLFiles recursively processes YAML files in the specified directory.

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -53,7 +53,7 @@ func newCmd() *cobra.Command {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Debugf("%+v", err)
 		os.Exit(1)
 	}
 }

--- a/src/cli/go.mod
+++ b/src/cli/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/h2non/gock.v1 v1.1.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -54,7 +54,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230629202037-9506855d4529 // indirect
 	google.golang.org/grpc v1.56.2 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/h2non/gock.v1 v1.1.2 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gorm.io/driver/postgres v1.5.2 // indirect
 	gorm.io/driver/sqlite v1.5.3 // indirect

--- a/src/cli/go.sum
+++ b/src/cli/go.sum
@@ -610,7 +610,6 @@ gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/src/pkg/go.mod
+++ b/src/pkg/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/cldcvr/terraform-config-inspect v0.0.0-20230821164346-f0b467a9714a
 	github.com/creack/pty v1.1.18
@@ -14,6 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rotisserie/eris v0.5.4

--- a/src/pkg/go.sum
+++ b/src/pkg/go.sum
@@ -40,6 +40,8 @@ github.com/AlecAivazis/survey/v2 v2.3.6 h1:NvTuVHISgTHEHeBFqt6BHOe4Ny/NwGZr7w+F8
 github.com/AlecAivazis/survey/v2 v2.3.6/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
+github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
@@ -161,6 +163,8 @@ github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2T
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
+github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69 h1:umaj0TCQ9lWUUKy2DxAhEzPbwd0jnxiw1EI2z3FiILM=
+github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69/go.mod h1:zdLK9ilQRSMjSeLKoZ4BqUfBT7jswTGF8zRlKEsiRXA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70 h1:xrd41BUTgqxyYFfFwGdt/bnwS8KNYzPraj8WgvJ5NWk=

--- a/src/pkg/metadata/app/utils.go
+++ b/src/pkg/metadata/app/utils.go
@@ -67,7 +67,7 @@ func (app *App) SetDefaults() {
 		app.EnvPrefix = strings.ToUpper(app.ID)
 	}
 
-	if app.Compute.ID == "" {
+	if app.Compute.ID == "" && app.Compute.Use != "" {
 		app.Compute.ID = app.ID
 	}
 
@@ -79,10 +79,6 @@ func (app *App) SetDefaults() {
 }
 
 func (dep *Dependency) SetDefaults() {
-	if dep.EnvPrefix == "" {
-		dep.EnvPrefix = strings.ToUpper(dep.ID)
-	}
-
 	if dep.Inputs == nil {
 		dep.Inputs = map[string]interface{}{}
 	}
@@ -90,6 +86,14 @@ func (dep *Dependency) SetDefaults() {
 	if strings.Contains(dep.Use, "@") {
 		split := strings.SplitN(dep.Use, "@", 2)
 		dep.Use, dep.Inputs["version"] = split[0], split[1]
+	}
+
+	if dep.ID == "" {
+		dep.ID = dep.Use
+	}
+
+	if dep.EnvPrefix == "" {
+		dep.EnvPrefix = strings.ToUpper(dep.ID)
 	}
 }
 
@@ -106,7 +110,10 @@ func (apps Apps) GetAppByID(id string) *App {
 
 // GetDependencies returns the dependencies for the app including it's deployment dependency.
 func (app App) GetDependencies() Dependencies {
-	allDeps := append(app.Dependencies, app.Compute)
+	allDeps := app.Dependencies
+	if app.Compute.ID != "" {
+		allDeps = append(app.Dependencies, app.Compute)
+	}
 
 	return allDeps
 }

--- a/src/pkg/metadata/app/utils_test.go
+++ b/src/pkg/metadata/app/utils_test.go
@@ -65,6 +65,7 @@ func TestSetDefaults(t *testing.T) {
 	apps := getAppsTest()
 
 	apps[0].Compute.ID = ""
+	apps[0].Dependencies[0].ID = ""
 
 	apps.SetDefaults()
 	for _, app := range apps {
@@ -75,6 +76,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 	}
 
+	assert.Equal(t, apps[0].Dependencies[0].ID, depPostgres)
 	assert.Equal(t, apps[0].Dependencies[0].Use, depPostgres)
 	assert.Equal(t, apps[0].Dependencies[0].Inputs["version"], "11")
 }

--- a/src/pkg/metadata/utils/appenv.go
+++ b/src/pkg/metadata/utils/appenv.go
@@ -1,0 +1,125 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cldcvr/terrarium/src/pkg/metadata/app"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/platform"
+	"github.com/hoisie/mustache"
+)
+
+const envValTemp = `{{ tr_component_%s_%s.value.%s }}` // 1. component-id, 2. output-name & 3. app-dependency-id
+
+// EnvVars array of env variables
+type EnvVars []EnvVar
+
+// EnvVar env variable Object
+type EnvVar struct {
+	Key, Value string
+}
+
+// GetAppEnvTemplate based on the app-dependencies, and component metadata,
+// generate a template for env variables such that the variables can be rendered later using
+// the terraform state output object.
+func GetAppEnvTemplate(pm *platform.PlatformMetadata, app app.App) EnvVars {
+	envVars := EnvVars{}
+	for _, appDep := range app.GetDependencies() {
+		comp := pm.Components.GetByID(appDep.Use)
+		if comp == nil || comp.Outputs == nil {
+			continue
+		}
+
+		depDefaults := getDepDefaults(comp, appDep)
+
+		finalOutputs := getRenderedOutputs(&appDep, depDefaults)
+
+		prefix := getEnvVarPrefix(app.EnvPrefix, appDep.EnvPrefix)
+
+		for k, v := range finalOutputs {
+			varName := prefix + k
+			envVars = append(envVars, EnvVar{varName, v})
+		}
+	}
+
+	return envVars
+}
+
+// getDepDefaults returns the default environment variables for a given component.
+func getDepDefaults(comp *platform.Component, appDep app.Dependency) map[string]string {
+	depDefaults := map[string]string{}
+	for outputName := range comp.Outputs.Properties {
+		depDefaults[outputName] = fmt.Sprintf(envValTemp, comp.ID, outputName, appDep.ID)
+	}
+	return depDefaults
+}
+
+// getRenderedOutputs updates the Outputs of appDep based on depDefaults.
+func getRenderedOutputs(appDep *app.Dependency, depDefaults map[string]string) (finalOutputs map[string]string) {
+	if len(appDep.Outputs) > 0 {
+		finalOutputs = make(map[string]string, len(appDep.Outputs))
+		for k, vTemp := range appDep.Outputs {
+			finalOutputs[k] = mustache.Render(vTemp, depDefaults)
+		}
+	} else {
+		finalOutputs = make(map[string]string, len(depDefaults))
+		for k, v := range depDefaults {
+			finalOutputs[strings.ToUpper(k)] = v
+		}
+	}
+
+	return
+}
+
+// getEnvVarPrefix returns the environment variable prefix based on app and appDep.
+func getEnvVarPrefix(appPrefix, depPrefix string) string {
+	prefix := ""
+	if appPrefix != "" {
+		prefix += appPrefix + "_"
+	}
+	if depPrefix != "" {
+		prefix += depPrefix + "_"
+	}
+	return prefix
+}
+
+func (e EnvVar) Render(quoteVal bool) string {
+	tmpl := "%s=%s"
+	if quoteVal {
+		tmpl = "%s=%q"
+	}
+	return fmt.Sprintf(tmpl, e.Key, e.Value)
+}
+
+func (vars EnvVars) render(quoteVal bool) string {
+	allVars := ""
+	for _, v := range vars {
+		allVars += v.Render(quoteVal) + "\n"
+	}
+	return allVars
+}
+
+func (vars EnvVars) Render() string {
+	return vars.render(false)
+}
+
+func (vars EnvVars) RenderWithQuotes() string {
+	return vars.render(true)
+}
+
+//  Implement sort.Interface to make EnvVars sortable by var name
+
+func (vars EnvVars) Len() int {
+	return len(vars)
+}
+
+func (vars EnvVars) Less(i, j int) bool {
+	return vars[i].Key < vars[j].Key
+}
+
+func (vars EnvVars) Swap(i, j int) {
+	vars[i], vars[j] = vars[j], vars[i]
+}

--- a/src/pkg/metadata/utils/appenv_test.go
+++ b/src/pkg/metadata/utils/appenv_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/cldcvr/terrarium/src/pkg/jsonschema"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/app"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/platform"
+	"github.com/hoisie/mustache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAppEnvTemplate(t *testing.T) {
+	type args struct {
+		pm  *platform.PlatformMetadata
+		app app.App
+	}
+	tests := []struct {
+		name string
+		args args
+		want EnvVars
+	}{
+		{
+			name: "default output no prefix",
+			args: args{
+				app: app.App{
+					Dependencies: app.Dependencies{
+						{
+							ID:      "mydep1",
+							Use:     "comp1",
+							Outputs: map[string]string{},
+						},
+					},
+				},
+				pm: &platform.PlatformMetadata{
+					Components: platform.Components{
+						{
+							ID: "comp1",
+							Outputs: &jsonschema.Node{
+								Properties: map[string]*jsonschema.Node{
+									"outp1": {},
+									"outp2": {},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: EnvVars{
+				{"OUTP1", `{{ tr_component_comp1_outp1.value.mydep1 }}`},
+				{"OUTP2", `{{ tr_component_comp1_outp2.value.mydep1 }}`},
+			},
+		},
+		{
+			name: "templated output with prefix",
+			args: args{
+				app: app.App{
+					EnvPrefix: "APP",
+					Dependencies: app.Dependencies{
+						{
+							ID:      "mydep1",
+							Use:     "comp1",
+							Outputs: map[string]string{},
+						},
+						{
+							ID:        "mydep2",
+							Use:       "comp1",
+							EnvPrefix: "MYDEP2",
+							Outputs: map[string]string{
+								"COMB": `combination of {{outp1}} and {{outp2}}`,
+							},
+						},
+						{
+							ID:      "mydep3",
+							Use:     "comp2",
+							Outputs: map[string]string{},
+						},
+					},
+				},
+				pm: &platform.PlatformMetadata{
+					Components: platform.Components{
+						{
+							ID: "comp1",
+							Outputs: &jsonschema.Node{
+								Properties: map[string]*jsonschema.Node{
+									"outp1": {},
+									"outp2": {},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: EnvVars{
+				{"APP_MYDEP2_COMB", `combination of {{ tr_component_comp1_outp1.value.mydep2 }} and {{ tr_component_comp1_outp2.value.mydep2 }}`},
+				{"APP_OUTP1", `{{ tr_component_comp1_outp1.value.mydep1 }}`},
+				{"APP_OUTP2", `{{ tr_component_comp1_outp2.value.mydep1 }}`},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAppEnvTemplate(tt.args.pm, tt.args.app)
+			sort.Sort(got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEnvVars(t *testing.T) {
+	tests := []struct {
+		name             string
+		vars             EnvVars
+		wantRender       string
+		wantRenderQuoted string
+	}{
+		{
+			vars: EnvVars{
+				{"APP_OUTP1", `{{ tr_component_comp1_outp1.value.mydep1 }}`},
+				{"APP_OUTP2", `{{ tr_component_comp1_outp2.value.mydep1 }}`},
+			},
+			wantRender: heredoc.Doc(`
+			APP_OUTP1={{ tr_component_comp1_outp1.value.mydep1 }}
+			APP_OUTP2={{ tr_component_comp1_outp2.value.mydep1 }}
+			`),
+			wantRenderQuoted: heredoc.Doc(`
+			APP_OUTP1="{{ tr_component_comp1_outp1.value.mydep1 }}"
+			APP_OUTP2="{{ tr_component_comp1_outp2.value.mydep1 }}"
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantRender, tt.vars.Render())
+			assert.Equal(t, tt.wantRenderQuoted, tt.vars.RenderWithQuotes())
+		})
+	}
+}
+
+func TestTemplate(t *testing.T) {
+	stateOut := map[string]interface{}{
+		"tr_component_postgres_host": map[string]interface{}{
+			"sensitive": false,
+			"type": []interface{}{
+				"object",
+				map[string]interface{}{"ledgerdb": "string"},
+			},
+			"value": map[string]interface{}{
+				"ledgerdb": "the value!",
+			},
+		},
+	}
+
+	tests := []struct {
+		name                     string
+		compID, compInp, depName string
+		want                     string
+	}{
+		{
+			name:    "string value",
+			compID:  "postgres",
+			compInp: "host",
+			depName: "ledgerdb",
+			want:    "the value!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			template := fmt.Sprintf(envValTemp, tt.compID, tt.compInp, tt.depName)
+			got := mustache.Render(template, stateOut)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/src/pkg/metadata/utils/appinputs.go
+++ b/src/pkg/metadata/utils/appinputs.go
@@ -1,0 +1,52 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"github.com/cldcvr/terrarium/src/pkg/metadata/app"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/platform"
+	pkgutils "github.com/cldcvr/terrarium/src/pkg/utils"
+	"github.com/rotisserie/eris"
+)
+
+// MatchAppAndPlatform validate app dependency inputs and set default inputs
+func MatchAppAndPlatform(pm *platform.PlatformMetadata, apps app.Apps) (err error) {
+	for _, app := range pkgutils.ToRefArr(apps) {
+		deps := pkgutils.ToRefArr(app.Dependencies)
+		if app.Compute.ID != "" {
+			deps = append(deps, &app.Compute)
+		}
+
+		for _, dep := range deps {
+			if !dep.NoProvision {
+				err = validateDependency(pm, dep)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateDependency validate and set default values to the dependency inputs.
+func validateDependency(pm *platform.PlatformMetadata, appDep *app.Dependency) error {
+	comp := pm.Components.GetByID(appDep.Use)
+	if comp == nil {
+		return eris.Errorf("component '%s.%s' is not implemented in the platform", appDep.ID, appDep.Use)
+	}
+
+	if appDep.Inputs == nil {
+		appDep.Inputs = map[string]interface{}{}
+	}
+
+	err := comp.Inputs.Validate(appDep.Inputs)
+	if err != nil {
+		return eris.Wrapf(err, "component '%s.%s' does not contain a valid set of inputs", appDep.ID, appDep.Use)
+	}
+
+	comp.Inputs.ApplyDefaultsToMSI(appDep.Inputs)
+	return nil
+}

--- a/src/pkg/metadata/utils/appinputs_test.go
+++ b/src/pkg/metadata/utils/appinputs_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/cldcvr/terrarium/src/pkg/jsonschema"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/app"
+	"github.com/cldcvr/terrarium/src/pkg/metadata/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestMatchAppAndPlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		pm       *platform.PlatformMetadata
+		apps     app.Apps
+		wantErr  bool
+		errMsg   string
+		wantApps app.Apps
+	}{
+		{
+			name: "Component not found in platform",
+			pm: &platform.PlatformMetadata{
+				Components: platform.Components{},
+			},
+			apps: app.Apps{
+				app.App{
+					ID: "testApp",
+					Dependencies: app.Dependencies{
+						app.Dependency{
+							ID:  "testDep",
+							Use: "missingComp",
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "component 'testDep.missingComp' is not implemented in the platform",
+		},
+		{
+			name: "Invalid input",
+			pm: &platform.PlatformMetadata{
+				Components: platform.Components{
+					{
+						ID: "comp1",
+						Inputs: &jsonschema.Node{
+							Type: gojsonschema.TYPE_OBJECT,
+							Properties: map[string]*jsonschema.Node{
+								"input1": {
+									Type: gojsonschema.TYPE_NUMBER,
+								},
+							},
+						},
+					},
+				},
+			},
+			apps: app.Apps{
+				app.App{
+					ID: "testApp",
+					Dependencies: app.Dependencies{
+						app.Dependency{
+							ID:  "testDep",
+							Use: "comp1",
+							Inputs: map[string]interface{}{
+								"input1": "not number",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "component 'testDep.comp1' does not contain a valid set of inputs: validation failed with following errors: \n\tinput1: Invalid type. Expected: number, given: string",
+		},
+		{
+			name: "Success set defaults",
+			pm: &platform.PlatformMetadata{
+				Components: platform.Components{
+					{
+						ID: "comp1",
+						Inputs: &jsonschema.Node{
+							Type: gojsonschema.TYPE_OBJECT,
+							Properties: map[string]*jsonschema.Node{
+								"input1": {
+									Type:    gojsonschema.TYPE_NUMBER,
+									Default: 10,
+								},
+								"input2": {
+									Type:    gojsonschema.TYPE_STRING,
+									Default: "val2",
+								},
+							},
+						},
+					},
+				},
+			},
+			apps: app.Apps{
+				app.App{
+					ID: "testApp",
+					Compute: app.Dependency{
+						ID:     "testComp",
+						Use:    "comp1",
+						Inputs: map[string]interface{}{},
+					},
+					Dependencies: app.Dependencies{
+						app.Dependency{
+							ID:  "testDep",
+							Use: "comp1",
+							Inputs: map[string]interface{}{
+								"input1": 20,
+							},
+						},
+					},
+				},
+			},
+			wantApps: app.Apps{
+				app.App{
+					ID: "testApp",
+					Compute: app.Dependency{
+						ID:  "testComp",
+						Use: "comp1",
+						Inputs: map[string]interface{}{
+							"input1": 10,
+							"input2": "val2",
+						},
+					},
+					Dependencies: app.Dependencies{
+						app.Dependency{
+							ID:  "testDep",
+							Use: "comp1",
+							Inputs: map[string]interface{}{
+								"input1": 20,
+								"input2": "val2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := MatchAppAndPlatform(tt.pm, tt.apps)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantApps, tt.apps)
+			}
+		})
+	}
+}

--- a/src/pkg/utils/array.go
+++ b/src/pkg/utils/array.go
@@ -1,0 +1,13 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+// ToRefArr convert array elements to reference
+func ToRefArr[T any](arr []T) (refArr []*T) {
+	refArr = make([]*T, len(arr))
+	for i := range arr {
+		refArr[i] = &arr[i]
+	}
+	return
+}

--- a/src/pkg/utils/array_test.go
+++ b/src/pkg/utils/array_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToRefArr(t *testing.T) {
+	t.Run("EmptyArray", func(t *testing.T) {
+		// Test when input array is empty.
+		arr := []string{}
+		refArr := ToRefArr(arr)
+		assert.Empty(t, refArr, "Resulting reference array should be empty")
+	})
+
+	t.Run("StringArray", func(t *testing.T) {
+		// Test when input array contains strings.
+		arr := []string{"apple", "banana", "cherry"}
+		refArr := ToRefArr(arr)
+		assert.Len(t, refArr, len(arr))
+
+		for i := 0; i < len(arr); i++ {
+			assert.Equal(t, &arr[i], refArr[i])
+		}
+	})
+
+	t.Run("IntArray", func(t *testing.T) {
+		// Test when input array contains integers.
+		arr := []int{1, 2, 3}
+		refArr := ToRefArr(arr)
+		assert.Len(t, refArr, len(arr))
+
+		for i := 0; i < len(arr); i++ {
+			assert.Equal(t, &arr[i], refArr[i])
+		}
+	})
+
+	t.Run("MixedTypeArray", func(t *testing.T) {
+		// Test when input array contains mixed types (string and int).
+		arr := []interface{}{"apple", 2, "cherry"}
+		refArr := ToRefArr(arr)
+		assert.Len(t, refArr, len(arr))
+
+		for i := 0; i < len(arr); i++ {
+			assert.Equal(t, &arr[i], refArr[i])
+		}
+	})
+}

--- a/src/pkg/utils/map.go
+++ b/src/pkg/utils/map.go
@@ -1,0 +1,31 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
+)
+
+func GetKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+func MapEachSortedKeys[K constraints.Ordered, V any](m map[K]V, fu func(K, V) error) (err error) {
+	keys := GetKeys(m)
+	slices.Sort(keys)
+	for _, k := range keys {
+		err = fu(k, m[k])
+		if err != nil {
+			return err
+		}
+	}
+
+	return
+}

--- a/src/pkg/utils/map_test.go
+++ b/src/pkg/utils/map_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKeys(t *testing.T) {
+	t.Run("EmptyMap", func(t *testing.T) {
+		// Test when input map is empty.
+		m := make(map[int]string)
+		keys := GetKeys(m)
+		assert.Empty(t, keys, "Resulting keys slice should be empty")
+	})
+
+	t.Run("IntStringMap", func(t *testing.T) {
+		// Test when input map contains integers as keys and strings as values.
+		m := map[int]string{
+			1: "one",
+			2: "two",
+			3: "three",
+		}
+		keys := GetKeys(m)
+		assert.Len(t, keys, len(m), "Length of resulting keys slice should match input map")
+
+		for k := range m {
+			assert.Contains(t, keys, k, "Keys slice should contain all keys from the input map")
+		}
+	})
+
+	t.Run("StringIntMap", func(t *testing.T) {
+		// Test when input map contains strings as keys and integers as values.
+		m := map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		}
+		keys := GetKeys(m)
+		assert.Len(t, keys, len(m), "Length of resulting keys slice should match input map")
+
+		for k := range m {
+			assert.Contains(t, keys, k, "Keys slice should contain all keys from the input map")
+		}
+	})
+}
+
+func TestMapEachSortedKeys(t *testing.T) {
+	t.Run("EmptyMap", func(t *testing.T) {
+		// Test when input map is empty.
+		m := make(map[int]string)
+		var processedKeys []int
+		err := MapEachSortedKeys(m, func(k int, v string) error {
+			processedKeys = append(processedKeys, k)
+			return nil
+		})
+		assert.NoError(t, err, "No error should be returned")
+		assert.Empty(t, processedKeys, "No keys should be processed")
+	})
+
+	t.Run("IntStringMap", func(t *testing.T) {
+		// Test when input map contains integers as keys and strings as values.
+		m := map[int]string{
+			3: "three",
+			1: "one",
+			2: "two",
+		}
+		var processedKeys []int
+		err := MapEachSortedKeys(m, func(k int, v string) error {
+			processedKeys = append(processedKeys, k)
+			return nil
+		})
+		assert.NoError(t, err, "No error should be returned")
+		assert.Equal(t, []int{1, 2, 3}, processedKeys, "Keys should be processed in sorted order")
+	})
+
+	t.Run("ErrorCallback", func(t *testing.T) {
+		// Test when the callback function returns an error.
+		m := map[int]string{
+			1: "one",
+			2: "two",
+		}
+		err := MapEachSortedKeys(m, func(k int, v string) error {
+			if k == 2 {
+				return eris.New("mocked error")
+			}
+			return nil
+		})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
after this change, the `terrarium generate` command generates the `*.env.mustache` file for each app in the destination folder.

These files looks something like this:

```sh
# app_banking_app.env.mustache
BA_LEDGERDB_HOST="{{ tr_component_postgres_host.value.ledgerdb }}"
BA_LEDGERDB_PASSWORD="{{ tr_component_postgres_password.value.ledgerdb }}"
BA_LEDGERDB_PORT="{{ tr_component_postgres_port.value.ledgerdb }}"
BA_LEDGERDB_USERNAME="{{ tr_component_postgres_username.value.ledgerdb }}"
```

as you can see, the env vars personalised for the app are templated referring to a value in terraform state file.
after provisioning infrastructure with terraform, one can render the above template by providing the terraform state file outputs to it. like this:
```
terraform output -json | mustache app_banking_app.env.mustache
```