### PR TITLE
TER-233 added support for sqlite seed data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "farm update",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/src/cli/terrarium/main.go",
+      "args": [
+        "farm",
+        "update"
+      ],
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceFolder}",
+    },
+    {
       "name": "Modules List",
       "type": "go",
       "request": "launch",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ secrets:
 
 services:
   postgres:
-    image: postgres:11
+    image: postgres:12
     container_name: postgres
     networks: [terrarium]
     environment:

--- a/src/cli/cmd/farm/cmd.go
+++ b/src/cli/cmd/farm/cmd.go
@@ -1,0 +1,23 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package farm
+
+import (
+	"github.com/cldcvr/terrarium/src/cli/cmd/farm/update"
+	"github.com/spf13/cobra"
+)
+
+var cmd *cobra.Command
+
+func NewCmd() *cobra.Command {
+	cmd = &cobra.Command{
+		Use:   "farm",
+		Short: "terrarium farm related commands",
+		Long:  `commands to access farm repository`,
+	}
+
+	cmd.AddCommand(update.NewCmd())
+
+	return cmd
+}

--- a/src/cli/cmd/farm/cmd_test.go
+++ b/src/cli/cmd/farm/cmd_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package farm
+
+import (
+	"testing"
+
+	"github.com/cldcvr/terrarium/src/pkg/testutils/clitesting"
+)
+
+func TestCmd(t *testing.T) {
+	clitest := clitesting.CLITest{
+		CmdToTest: NewCmd,
+	}
+
+	clitest.RunTests(t, []clitesting.CLITestCase{
+		{
+			Name:           "farm help",
+			ValidateOutput: clitesting.ValidateOutputContains("commands to access farm repository\n\nUsage:\n  farm [command]\n\nAvailable Commands:\n  completion  Generate the autocompletion script for the specified shell\n  help        Help about any command\n  update      farm update updates the databse with latest farm release\n\nFlags:\n  -h, --help   help for farm\n\nUse \"farm [command] --help\" for more information about a command.\n"),
+		},
+	})
+}

--- a/src/cli/cmd/farm/update/cmd.go
+++ b/src/cli/cmd/farm/update/cmd.go
@@ -1,0 +1,91 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package update
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/cldcvr/terrarium/src/cli/internal/config"
+	"github.com/rotisserie/eris"
+	"github.com/spf13/cobra"
+)
+
+const (
+	artifactName = "cc_terrarium_data.sql.gz"
+)
+
+var (
+	cmd *cobra.Command
+)
+
+func NewCmd() *cobra.Command {
+	cmd = &cobra.Command{
+		Use:   "update",
+		Short: "farm update updates the databse with latest farm release",
+		RunE:  cmdRunE,
+	}
+	return cmd
+}
+
+func cmdRunE(cmd *cobra.Command, args []string) error {
+
+	dumpFilePath, err := downloadArtifact(config.FarmDefault(), config.FarmVersion(), artifactName)
+	if err != nil {
+		return err
+	}
+
+	gzFile, err := os.Open(filepath.Join(dumpFilePath, artifactName))
+	if err != nil {
+		return eris.Wrap(err, "error opening file: %v")
+	}
+	defer gzFile.Close()
+
+	gzReader, err := gzip.NewReader(gzFile)
+	if err != nil {
+		return eris.Wrap(err, "error creating gzip reader: %v")
+	}
+	defer gzReader.Close()
+
+	dumpContent, err := io.ReadAll(gzReader)
+	if err != nil {
+		return eris.Wrap(err, "error reading content: %v")
+	}
+
+	return seedDatabase(string(dumpContent))
+}
+
+func downloadArtifact(repo, releaseTag, artifactName string) (string, error) {
+	resp, err := http.Get(fmt.Sprintf("https://%s/releases/download/%s/%s", repo, releaseTag, artifactName))
+	if err != nil {
+		return "", eris.Wrap(err, "error sending HTTP request: %v")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", eris.Errorf("HTTP request failed with status code %d", resp.StatusCode)
+	}
+
+	tempDir := filepath.Join(os.TempDir(), "farm-artifact")
+	err = os.MkdirAll(tempDir, os.ModePerm)
+	if err != nil {
+		return "", eris.Wrap(err, "error creating temporary directory: %v")
+	}
+
+	outFile, err := os.Create(filepath.Join(tempDir, artifactName))
+	if err != nil {
+		return "", eris.Wrap(err, "error creating output file: %v")
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, resp.Body)
+	if err != nil {
+		return "", eris.Wrap(err, "error copying artifact to output file: %v")
+	}
+	return tempDir, nil
+}

--- a/src/cli/cmd/farm/update/cmd_test.go
+++ b/src/cli/cmd/farm/update/cmd_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build mock
+// +build mock
+
+package update
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cldcvr/terrarium/src/cli/internal/config"
+	"github.com/cldcvr/terrarium/src/pkg/db/mocks"
+	"github.com/cldcvr/terrarium/src/pkg/testutils/clitesting"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestCmd(t *testing.T) {
+	config.LoadDefaults()
+	clitest := clitesting.CLITest{
+		CmdToTest: NewCmd,
+	}
+	mockDB := &mocks.DB{}
+	mockDB.On("ExecuteSQLStatement", mock.Anything).Return(func(dump string) error {
+		if strings.Contains(dump, "fail") {
+			return fmt.Errorf("mock error")
+		}
+		return nil
+	})
+	config.SetDBMocks(mockDB)
+
+	clitest.RunTests(t, []clitesting.CLITestCase{
+		{
+			Name: "success",
+			GockSetup: func(ctx context.Context, t *testing.T) {
+				var buf bytes.Buffer
+				gzWriter := gzip.NewWriter(&buf)
+				gzWriter.Write([]byte("some dummy SQL command;"))
+				gzWriter.Close()
+
+				gock.New("https://github.com").
+					Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+					Reply(http.StatusOK).
+					Body(bytes.NewReader(buf.Bytes())).
+					SetHeader("Content-Encoding", "gzip")
+			},
+		},
+		{
+			Name: "download artifact non ok http response",
+			GockSetup: func(ctx context.Context, t *testing.T) {
+				gock.New("https://github.com").
+					Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+					Reply(http.StatusInternalServerError).
+					SetHeader("Content-Encoding", "gzip")
+			},
+			ExpError: "HTTP request failed with status code 500",
+			WantErr:  true,
+		},
+		{
+			Name: "invalid artifact failure",
+			GockSetup: func(ctx context.Context, t *testing.T) {
+				gock.New("https://github.com").
+					Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+					Reply(http.StatusOK)
+			},
+			ExpError: "error creating gzip reader",
+			WantErr:  true,
+		},
+		{
+			Name: "failure executing SQL statement",
+			GockSetup: func(ctx context.Context, t *testing.T) {
+				var buf bytes.Buffer
+				gzWriter := gzip.NewWriter(&buf)
+				gzWriter.Write([]byte("failure"))
+				gzWriter.Close()
+
+				gock.New("https://github.com").
+					Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+					Reply(http.StatusOK).
+					Body(bytes.NewReader(buf.Bytes())).
+					SetHeader("Content-Encoding", "gzip")
+			},
+			ExpError: "error executing dump file: mock error",
+			WantErr:  true,
+		},
+	})
+}
+
+func setupGockSuccess(ctx context.Context, t *testing.T) {
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	gzWriter.Write([]byte("some dummy SQL command;"))
+	gzWriter.Close()
+
+	gock.New("https://github.com").
+		Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+		Reply(http.StatusOK).
+		Body(bytes.NewReader(buf.Bytes())).
+		SetHeader("Content-Encoding", "gzip")
+}
+
+func setupGockFailure(ctx context.Context, t *testing.T) {
+	gock.New("https://github.com").
+		Get("/cldcvr/terrarium-farm/releases/download/latest/cc_terrarium_data.sql.gz").
+		Reply(http.StatusInternalServerError).
+		SetHeader("Content-Encoding", "gzip")
+	return
+}

--- a/src/cli/cmd/farm/update/data.go
+++ b/src/cli/cmd/farm/update/data.go
@@ -1,0 +1,41 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package update
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cldcvr/terrarium/src/cli/internal/config"
+	"github.com/cldcvr/terrarium/src/pkg/db"
+	"github.com/rotisserie/eris"
+)
+
+func executeSQLStatement(db db.DB, sqlStatement string) error {
+	return db.ExecuteSQLStatement(sqlStatement)
+}
+
+func seedDatabase(dumpContent string) error {
+	dump := cleanup(dumpContent)
+	g, err := config.DBConnect()
+	if err != nil {
+		return eris.Wrap(err, "failed to connect DB")
+	}
+	err = executeSQLStatement(g, dump)
+	if err != nil {
+		return eris.Wrap(err, "error executing dump file")
+	}
+	return nil
+}
+
+func cleanup(dump string) string {
+	dump = strings.ReplaceAll(dump, "public.", "")
+	setPattern := `(?m)^SET.*$`
+	re := regexp.MustCompile(setPattern)
+	dump = re.ReplaceAllString(dump, "")
+
+	selectPattern := `(?m)^SELECT.*$`
+	res := regexp.MustCompile(selectPattern)
+	return res.ReplaceAllString(dump, "")
+}

--- a/src/cli/cmd/farm/update/data_test.go
+++ b/src/cli/cmd/farm/update/data_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build mock
+// +build mock
+
+package update
+
+import "testing"
+
+func Test_cleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		dump string
+		want string
+	}{
+		{
+			name: "success",
+			dump: "INSERT INTO public.taxonomies valid sql statement; \nSET some statement; \nSELECT some statement;",
+			want: "INSERT INTO taxonomies valid sql statement; \n\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanup(tt.dump); got != tt.want {
+				t.Errorf("cleanup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -6,8 +6,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/charmbracelet/log"
+	"github.com/cldcvr/terrarium/src/cli/cmd/farm"
 	"github.com/cldcvr/terrarium/src/cli/cmd/generate"
 	"github.com/cldcvr/terrarium/src/cli/cmd/harvest"
 	"github.com/cldcvr/terrarium/src/cli/cmd/platform"
@@ -42,8 +44,9 @@ func newCmd() *cobra.Command {
 	rootCmd.AddCommand(generate.NewCmd())
 	rootCmd.AddCommand(version.NewCmd())
 	rootCmd.AddCommand(query.NewCmd())
+	rootCmd.AddCommand(farm.NewCmd())
 
-	rootCmd.PersistentFlags().StringVar(&flagCfgFile, "config", "", "config file (default is $HOME/.terrarium.yaml)")
+	rootCmd.PersistentFlags().StringVar(&flagCfgFile, "config", "", "config file (default is $HOME/.terrarium/config.yaml)")
 
 	return rootCmd
 }
@@ -68,9 +71,9 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// Search config in home directory with name ".terrarium" (without extension)
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".terrarium")
+		// Search config in `$HOME/.terrarium` directory with name "config" (without extension)
+		viper.AddConfigPath(filepath.Join(home, ".terrarium"))
+		viper.SetConfigName("config")
 	}
 
 	// If a config file is found, read it in.

--- a/src/cli/internal/config/database.go
+++ b/src/cli/internal/config/database.go
@@ -4,10 +4,14 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/cldcvr/terrarium/src/pkg/confighelper"
 	"github.com/cldcvr/terrarium/src/pkg/db"
 	"github.com/cldcvr/terrarium/src/pkg/db/dbhelper"
 	"github.com/cldcvr/terrarium/src/pkg/db/mocks"
+	"github.com/mitchellh/go-homedir"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 )
@@ -80,7 +84,15 @@ func DBConnect() (db.DB, error) {
 		}
 		return mockdb, nil
 	case "sqlite":
-		g, err = dbhelper.ConnectSQLite(DBDSN())
+		dir, err := homedir.Expand(filepath.Dir(DBDSN()))
+		if err != nil {
+			return nil, eris.Wrap(err, "could not locate the DB file location")
+		}
+		err = os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return nil, eris.Wrap(err, "could not create/access DB file location")
+		}
+		g, err = dbhelper.ConnectSQLite(filepath.Join(dir, filepath.Base(DBDSN())))
 		if err != nil {
 			return nil, eris.Wrap(err, "could not establish a connection to the database")
 		}

--- a/src/cli/internal/config/defaults.yaml
+++ b/src/cli/internal/config/defaults.yaml
@@ -17,17 +17,17 @@
 # The following is the default configuration:
 
 db:
-  host: "localhost"      # db host name
-  user: "postgres"       # db username
-  password: ""           # db password no default, panic if not set.
-  name: "cc_terrarium"   # database name
-  port: 5432             # db port
-  ssl_mode: false        # enable SSL mode
-  type: postgres         # type of db - postgres | sqlite
-  dsn: embedded.db       # SQLite Data Source Name
-  retry_attempts: 0      # max number of re-tries on connection request failure
-  retry_interval_sec: 3  # time to wait for (in seconds) before each retry
-  retry_jitter_sec: 0    # additional random time (in seconds) between 0 and this, to be added to the wait time
+  host: "localhost"              # db host name
+  user: "postgres"               # db username
+  password: ""                   # db password
+  name: "cc_terrarium"           # database name
+  port: 5432                     # db port
+  ssl_mode: false                # enable SSL mode
+  type: postgres                 # type of db - postgres | sqlite
+  dsn: ~/.terrarium/farm.sqlite  # SQLite Data Source Name
+  retry_attempts: 0              # max number of re-tries on connection request failure
+  retry_interval_sec: 3          # time to wait for (in seconds) before each retry
+  retry_jitter_sec: 0            # additional random time (in seconds) between 0 and this, to be added to the wait time
 
 log:
   format: "text"        # log format - text | json
@@ -38,3 +38,4 @@ terraform:
 
 farm:
   default: github.com/cldcvr/terrarium-farm  # link of the farm repo to use by default
+  version: latest # release tag to use

--- a/src/cli/internal/config/farm.go
+++ b/src/cli/internal/config/farm.go
@@ -9,3 +9,8 @@ import "github.com/cldcvr/terrarium/src/pkg/confighelper"
 func FarmDefault() string {
 	return confighelper.MustGetString("farm.default")
 }
+
+// FarmVersion version of the farm repo to use by default
+func FarmVersion() string {
+	return confighelper.MustGetString("farm.version")
+}

--- a/src/pkg/db/mocks/DB.go
+++ b/src/pkg/db/mocks/DB.go
@@ -222,6 +222,20 @@ func (_m *DB) CreateTaxonomy(e *db.Taxonomy) (uuid.UUID, error) {
 	return r0, r1
 }
 
+// ExecuteSQLStatement provides a mock function with given fields: _a0
+func (_m *DB) ExecuteSQLStatement(_a0 string) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // FindOutputMappingsByModuleID provides a mock function with given fields: ids
 func (_m *DB) FindOutputMappingsByModuleID(ids ...uuid.UUID) (db.TFModules, error) {
 	_va := make([]interface{}, len(ids))

--- a/src/pkg/db/utils.go
+++ b/src/pkg/db/utils.go
@@ -38,6 +38,8 @@ type DB interface {
 
 	// FindOutputMappingsByModuleID DEPRECATED fetch the terraform module along with it's attribute and output mappings of the attribute.
 	FindOutputMappingsByModuleID(ids ...uuid.UUID) (result TFModules, err error)
+
+	ExecuteSQLStatement(string) error
 }
 
 type FilterOption func(*gorm.DB) *gorm.DB
@@ -126,4 +128,8 @@ func PaginateGlobalFilter(pageSize, pageIndex int32, totalPages *int32) FilterOp
 
 func NoOpFilter(g *gorm.DB) *gorm.DB {
 	return g
+}
+
+func (db *gDB) ExecuteSQLStatement(statement string) error {
+	return db.g().Exec(statement).Error
 }


### PR DESCRIPTION
-In a nutshell, these changes introduce `farm update` command. The command is responsible to create (if not created) sqlite DB file with name `farm.sqlite` and populate the DB with farm repo's data dump.
-there is a corresponding change in [terrarium-farm](https://github.com/cldcvr/terrarium-farm/pull/11) as well which ensure that we generate the required/desired dump file as part of release artifact.
-It also changes the postgres image from 11 to 12 as we needed a flag names `rows-per-insert` which is supported from 12 onwards.
-It enables CGO as [it is required with sqlite](https://pkg.go.dev/github.com/mattn/go-sqlite3#section-readme:~:text=This%20package%20requires%20the%20CGO_ENABLED%3D1).
-It changes the location of configuration file from `$HOME/.terrarium.yaml` to `$HOME/.terrarium/config.yaml`. 
-`$HOME/.terrarium` is also the location for sqlite DB file.

- [x] Unit tests
- [x] release artifact download without github cli