### PR TITLE
TER-254 Change standard errors to eris

### DIFF
--- a/src/cli/cmd/generate/cmd_test.go
+++ b/src/cli/cmd/generate/cmd_test.go
@@ -29,7 +29,7 @@ func TestCmd(t *testing.T) {
 		},
 		{
 			Name:           "Success (no profile)",
-			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be/terrarium.yaml", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium"},
+			Args:           []string{"-p", "../../../../examples/platform/", "-a", "../../../../examples/apps/voting-be", "-a", "../../../../examples/apps/voting-worker", "-o", "./testdata/.terrarium"},
 			ValidateOutput: clitesting.ValidateOutputMatch("Successfully pulled 13 of 22 terraform blocks at: ./testdata/.terrarium\n"),
 		},
 		{

--- a/src/cli/cmd/generate/generate_test.go
+++ b/src/cli/cmd/generate/generate_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package generate
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_copyFile(t *testing.T) {
+	type args struct {
+		srcPath string
+		dstPath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "fail on source (not exists)",
+			args: args{
+				srcPath: "/ggsgsd/rthrtyytjurtkuykkuyyukruy/cambridgeshire.emf.fnc",
+				dstPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail on source (not file)",
+			args: args{
+				srcPath: os.TempDir(),
+				dstPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail on destination (not file)",
+			args: args{
+				srcPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+				dstPath: os.TempDir(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "successful copy (dest overwrite)",
+			args: args{
+				srcPath: mustCreateFile(t, []byte("Totam facere iusto laborum eum possimus sint harum.\nRepudiandae possimus nulla autem dolorem fuga veniam.\n")),
+				dstPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful copy (dest not exists)",
+			args: args{
+				srcPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+				dstPath: path.Join(os.TempDir(), "generate.tmo"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful empty copy",
+			args: args{
+				srcPath: mustCreateFile(t, nil),
+				dstPath: mustCreateFile(t, []byte("Sint non incidunt ipsam et.\n")),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := copyFile(tt.args.srcPath, tt.args.dstPath); (err != nil) != tt.wantErr {
+				t.Errorf("copyFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				assertFileSame(t, tt.args.srcPath, tt.args.dstPath)
+			}
+		})
+	}
+}
+
+func mustCreateFile(t *testing.T, contents []byte) string {
+	fp, err := os.CreateTemp("", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fp.Close()
+	if len(contents) > 0 {
+		if _, err := fp.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return fp.Name()
+}
+
+func assertFileSame(t *testing.T, filePathExpected string, filePathActual string) {
+	expected, err := os.ReadFile(filePathExpected)
+	assert.NoError(t, err)
+
+	actual, err := os.ReadFile(filePathActual)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}

--- a/src/cli/cmd/harvest/dependencies/dependencies.go
+++ b/src/cli/cmd/harvest/dependencies/dependencies.go
@@ -63,7 +63,7 @@ func processYAMLData(g db.DB, path string, data []byte) error {
 			for i, level := range levels {
 				tax, err := g.GetTaxonomyByFieldName(fmt.Sprintf("level%d", i+1), level)
 				if err != nil {
-					return err
+					return eris.Wrap(err, "error getting taxonomy data")
 				}
 				dbTax = tax
 			}

--- a/src/cli/cmd/harvest/mappings/mappings.go
+++ b/src/cli/cmd/harvest/mappings/mappings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/pkg/db"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 )
 
@@ -55,7 +56,7 @@ func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Reso
 			ProviderID:     dstResDB.ProviderID,
 			AttributePath:  dstResInputName,
 		}); err != nil {
-			return nil, fmt.Errorf("unknown resource-attribute record %s: %v", fmtAttrMeta(dstRes.Type, dstRes.Name, dstResInputName, dstRes.Pos.Filename, dstRes.Pos.Line), err)
+			return nil, eris.Wrapf(err, "unknown resource-attribute record %s", fmtAttrMeta(dstRes.Type, dstRes.Name, dstResInputName, dstRes.Pos.Filename, dstRes.Pos.Line))
 		}
 
 		mappingDB := &db.TFResourceAttributesMapping{
@@ -63,7 +64,7 @@ func createMappingRecord(g db.DB, parent *tfconfig.Module, dstRes *tfconfig.Reso
 			OutputAttributeID: srcAttrDB.ID,
 		}
 		if _, err := g.CreateTFResourceAttributesMapping(mappingDB); err != nil {
-			return nil, fmt.Errorf("error creating attribut-mapping record: %v", err)
+			return nil, eris.Wrap(err, "error creating attribut-mapping record")
 		}
 		return mappingDB, nil
 	}

--- a/src/cli/cmd/harvest/modules/modules.go
+++ b/src/cli/cmd/harvest/modules/modules.go
@@ -4,13 +4,13 @@
 package modules
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	cliconfig "github.com/cldcvr/terrarium/src/cli/internal/config"
 	"github.com/cldcvr/terrarium/src/pkg/db"
+	"github.com/rotisserie/eris"
 )
 
 type tfValue interface {
@@ -51,7 +51,7 @@ func createAttributeRecord(g db.DB, moduleDB *db.TFModule, v tfValue, varAttribu
 		// we store all sub-paths such as 'rule.noncurrent_version_expiration.newer_noncurrent_versions'
 		// but the output or input variable may be refering to 'rule.noncurrent_version_expiration' portion only
 		// we should treat each "path-level" as an attribute of its own - other modules may use it as input
-		// return nil, fmt.Errorf("unknown resource-attribute record: %v", err)
+		// return nil, eris.Wrap(err, "unknown resource-attribute record")
 		return nil, nil
 	}
 
@@ -70,7 +70,7 @@ func createAttributeRecord(g db.DB, moduleDB *db.TFModule, v tfValue, varAttribu
 	}
 
 	if _, err := g.CreateTFModuleAttribute(moduleAttrDB); err != nil {
-		return nil, fmt.Errorf("error creating module-attribute record: %v", err)
+		return nil, eris.Wrap(err, "error creating module-attribute record")
 	}
 
 	return moduleAttrDB, nil

--- a/src/cli/cmd/platform/lint/cmd.go
+++ b/src/cli/cmd/platform/lint/cmd.go
@@ -4,9 +4,9 @@
 package lint
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/rotisserie/eris"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +44,7 @@ func cmdRunE(cmd *cobra.Command, args []string) error {
 
 func checkDirExists(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return fmt.Errorf("could not open given directory '%s': %w", dir, err)
+		return eris.Wrapf(err, "could not open given directory '%s'", dir)
 	}
 	return nil
 }

--- a/src/cli/cmd/query/modules/modules.go
+++ b/src/cli/cmd/query/modules/modules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cldcvr/terrarium/src/pkg/db"
 	"github.com/cldcvr/terrarium/src/pkg/pb/terrariumpb"
 	"github.com/cldcvr/terrarium/src/pkg/transporthelper"
+	"github.com/rotisserie/eris"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,7 @@ func NewCmd() *cobra.Command {
 func listModules(cmd *cobra.Command, args []string) error {
 	g, err := config.DBConnect()
 	if err != nil {
-		return err
+		return eris.Wrap(err, "error accessing database")
 	}
 
 	page := &terrariumpb.Page{
@@ -61,7 +62,7 @@ func listModules(cmd *cobra.Command, args []string) error {
 		db.ModuleNamespaceFilter(flagNamespaces),
 	)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "error getting available modules")
 	}
 
 	pbRes := &terrariumpb.ListModulesResponse{
@@ -72,7 +73,7 @@ func listModules(cmd *cobra.Command, args []string) error {
 	if flagOutputFormat == "json" {
 		b, err := transporthelper.CreateJSONBodyMarshaler().Marshaler.Marshal(pbRes)
 		if err != nil {
-			return err
+			return eris.Wrap(err, "error formatting module list")
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), string(b))
 

--- a/src/cli/go.mod
+++ b/src/cli/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/charmbracelet/log v0.2.3
 	github.com/cldcvr/terraform-config-inspect v0.0.0-20230821164346-f0b467a9714a
-	github.com/cldcvr/terrarium/src/pkg v0.0.0-20230828104842-b967825be600
+	github.com/cldcvr/terrarium/src/pkg v0.0.0-20230911180813-4861be5a2cea
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -26,12 +26,14 @@ require (
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/creack/pty v1.1.18 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
+	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 // indirect
+	github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.3.1 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/src/cli/go.sum
+++ b/src/cli/go.sum
@@ -60,8 +60,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cldcvr/terraform-config-inspect v0.0.0-20230821164346-f0b467a9714a h1:47liIoRszf296yCiizDcxvCDoKv1udOEmlF38QMBRlA=
 github.com/cldcvr/terraform-config-inspect v0.0.0-20230821164346-f0b467a9714a/go.mod h1:ShRLLsTzQkWbsyOtlwgSrUhe0Lx4crE1DVgC5OgyZew=
-github.com/cldcvr/terrarium/src/pkg v0.0.0-20230828104842-b967825be600 h1:yTMGy945/VE5Z06N/3CJUZ/t0nYFT6Zx47D2PfPTnlY=
-github.com/cldcvr/terrarium/src/pkg v0.0.0-20230828104842-b967825be600/go.mod h1:YvPXKyoadLJTinkuk0rVPZGieIc4cqQOvTdjMxqn2ao=
+github.com/cldcvr/terrarium/src/pkg v0.0.0-20230911180813-4861be5a2cea h1:xLRewm9THkFhsono4Wp2COEof4jXJZKOA0PJOfQlPC4=
+github.com/cldcvr/terrarium/src/pkg v0.0.0-20230911180813-4861be5a2cea/go.mod h1:gbnPoWYht5BFHfHhrBE1fS4aNeHLAW2F5EUHI+qksvY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -87,6 +87,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=
+github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEaizzs=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
@@ -172,6 +174,10 @@ github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70 h1:xrd41BUTgqxyYFfFwGdt/bnwS8KNYzPraj8WgvJ5NWk=
+github.com/icza/backscanner v0.0.0-20230330133933-bf6beb754c70/go.mod h1:GYeBD1CF7AqnKZK+UCytLcY3G+UKo0ByXX/3xfdNyqQ=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6 h1:8UsGZ2rr2ksmEru6lToqnXgA8Mz1DP11X4zSJ159C3k=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -240,6 +246,8 @@ github.com/rotisserie/eris v0.5.4 h1:Il6IvLdAapsMhvuOahHWiBnl1G++Q0/L5UIkI5mARSk
 github.com/rotisserie/eris v0.5.4/go.mod h1:Z/kgYTJiJtocxCbFfvRmO+QejApzG6zpyky9G1A4g9s=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
@@ -421,6 +429,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=

--- a/src/pkg/db/dbhelper/connection.go
+++ b/src/pkg/db/dbhelper/connection.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cldcvr/terrarium/src/pkg/utils"
+	"github.com/rotisserie/eris"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -32,7 +33,7 @@ func Connect(dialector gorm.Dialector, options ...ConnOption) (*gorm.DB, error) 
 		return err
 	})
 
-	return db, err
+	return db, eris.Wrap(err, "error connecting to database")
 }
 
 // createPostgresDSN creates the DSN (Data Source Name) string for the postgres database connection.

--- a/src/pkg/go.mod
+++ b/src/pkg/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/src/pkg/jsonschema/schema.go
+++ b/src/pkg/jsonschema/schema.go
@@ -49,7 +49,7 @@ func (n *Node) Compile() (err error) {
 func (n *Node) Validate(val interface{}) error {
 	err := n.compileIfNot()
 	if err != nil {
-		return err
+		return eris.Wrapf(err, "failed to compile validation schema")
 	}
 
 	result, err := n.compiled.Validate(gojsonschema.NewGoLoader(val))

--- a/src/pkg/metadata/platform/graph.go
+++ b/src/pkg/metadata/platform/graph.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 )
 
@@ -83,12 +84,12 @@ func (g *Graph) Walk(roots []BlockID, cb GraphWalkerCB) error {
 
 	err := g.traverseRootBlocks(&traverser, cb)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "error traversing hcl blocks")
 	}
 
 	err = g.traverseOutputBlocks(&traverser, cb)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "error traversing hcl output blocks")
 	}
 
 	return nil

--- a/src/pkg/metadata/platform/graph_test.go
+++ b/src/pkg/metadata/platform/graph_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
+	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,7 +149,7 @@ func TestWalk(t *testing.T) {
 			graph: defaultG,
 			roots: []BlockID{"A"},
 			walkerCB: func(blockId BlockID) error {
-				return errors.New("error in walker function")
+				return eris.New("error in walker function")
 			},
 			expectedError: errors.New("error in walker function"),
 		},
@@ -158,7 +159,7 @@ func TestWalk(t *testing.T) {
 			roots: []BlockID{"A"},
 			walkerCB: func(blockId BlockID) error {
 				if t, _ := blockId.Parse(); t == BlockType_Output {
-					return errors.New("error in output function")
+					return eris.New("error in output function")
 				}
 				return nil
 			},
@@ -181,9 +182,11 @@ func TestWalk(t *testing.T) {
 
 			err := tt.graph.Walk(tt.roots, cb)
 
-			assert.Equal(t, tt.expectedError, err)
 			if tt.expectedError == nil {
+				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedPath, traversed)
+			} else {
+				assert.True(t, eris.Is(err, tt.expectedError))
 			}
 		})
 	}

--- a/src/pkg/tf/runner/utils.go
+++ b/src/pkg/tf/runner/utils.go
@@ -3,12 +3,14 @@
 
 package runner
 
+import "github.com/rotisserie/eris"
+
 func TerraformProviderSchema(runner *terraformRunner, dir string, outFilePath string) error {
 	if err := TerraformInit(runner, dir); err != nil {
-		return err
+		return eris.Wrap(err, "error initilizing terraform working directory")
 	}
 	if err := runner.RunTerraformProvidersSchema(dir, outFilePath); err != nil {
-		return err
+		return eris.Wrap(err, "error getting terraform providers schema")
 	}
 
 	return nil
@@ -16,10 +18,10 @@ func TerraformProviderSchema(runner *terraformRunner, dir string, outFilePath st
 
 func TerraformInit(runner *terraformRunner, dir string) error {
 	if err := runner.RunTerraformVersion(); err != nil {
-		return err
+		return eris.Wrap(err, "error getting terraform version")
 	}
 	if err := runner.RunTerraformInit(dir); err != nil {
-		return err
+		return eris.Wrap(err, "error running terraform init")
 	}
 
 	return nil

--- a/src/pkg/tf/writer/locals.go
+++ b/src/pkg/tf/writer/locals.go
@@ -16,7 +16,7 @@ func WriteLocals(val map[string]interface{}, out io.Writer) error {
 	// Convert the map to cty.Value
 	ctyData, err := utils.ToCtyValue(val)
 	if err != nil {
-		return err
+		return eris.Wrapf(err, "error converting given value to hcl: %v", val)
 	}
 	data := ctyData.AsValueMap()
 

--- a/src/pkg/transporthelper/server.go
+++ b/src/pkg/transporthelper/server.go
@@ -155,7 +155,7 @@ func runAsync(ctx context.Context, host string, srv interface{ Serve(net.Listene
 		defer close(result)
 		defer func() {
 			if p := recover(); p != nil {
-				result <- fmt.Errorf("server task has failed with unhandled panic: %v\n%s", p, debug.Stack())
+				result <- eris.Errorf("server task has failed with unhandled panic: %v\n%s", p, debug.Stack())
 			}
 		}()
 		result <- srv.Serve(listener)

--- a/src/pkg/utils/vt10x.go
+++ b/src/pkg/utils/vt10x.go
@@ -4,11 +4,10 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/Netflix/go-expect"
 	pseudotty "github.com/creack/pty"
 	"github.com/hinshun/vt10x"
+	"github.com/rotisserie/eris"
 )
 
 var (
@@ -21,13 +20,13 @@ var (
 func NewVT10XConsole(opts ...expect.ConsoleOpt) (*expect.Console, error) {
 	pty, tty, err := pseudotty.Open()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open pseudotty: %v", err)
+		return nil, eris.Wrap(err, "failed to open pseudotty")
 	}
 
 	term := vt10x.New(vt10x.WithWriter(tty))
 	c, err := expectNewConsole(append(opts, expect.WithStdin(pty), expect.WithStdout(term), expect.WithCloser(pty, tty))...)
 	if err != nil {
-		return nil,  fmt.Errorf("failed to create console: %v", err)
+		return nil, eris.Wrap(err, "failed to create console")
 	}
 
 	return c, nil


### PR DESCRIPTION
As much as possible wrap the errors in eris error wrappers.

This improves error context and also avoids mixing two error styles.