### PR TITLE
TER-241 Allow reusing workdir in harvest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,10 @@ install:  ## Install the CLI native binary into GOBIN
 # Needs terraform installed on the system
 ######################################################
 
+ifeq ($(HARVEST_WD),)
+HARVEST_WD := /tmp/harvest
+endif
+
 ifeq ($(FARM_DIR),)
 FARM_DIR := examples/farm
 endif
@@ -177,15 +181,18 @@ farm-harvest: farm-resource-harvest farm-module-harvest farm-mapping-harvest  fa
 
 .PHONY: farm-resource-harvest  ## Harvest terraform provider resources from module list file
 farm-resource-harvest: $(FARM_DIR)/modules.yaml
-	terrarium harvest resources --module-list-file $(FARM_DIR)/modules.yaml
+	@mkdir -p $(HARVEST_WD)
+	terrarium harvest resources --module-list-file $(FARM_DIR)/modules.yaml --workdir $(HARVEST_WD)
 
 .PHONY: farm-module-harvest  ## Harvest terraform modules from module list file
 farm-module-harvest: $(FARM_DIR)/modules.yaml
-	terrarium harvest modules --module-list-file $(FARM_DIR)/modules.yaml
+	@mkdir -p $(HARVEST_WD)
+	terrarium harvest modules --module-list-file $(FARM_DIR)/modules.yaml --workdir $(HARVEST_WD)
 
 .PHONY: farm-mapping-harvest  ## Harvest attribute mappings from module list file
 farm-mapping-harvest: $(FARM_DIR)/modules.yaml
-	terrarium harvest mappings --module-list-file $(FARM_DIR)/modules.yaml
+	@mkdir -p $(HARVEST_WD)
+	terrarium harvest mappings --module-list-file $(FARM_DIR)/modules.yaml --workdir $(HARVEST_WD)
 
 .PHONY: farm-dependency-harvest  ## Harvest dependency interface from the farm directory
 farm-dependency-harvest: $(FARM_DEPENDENCY_DIR)

--- a/src/cli/cmd/harvest/mappings/cmd.go
+++ b/src/cli/cmd/harvest/mappings/cmd.go
@@ -21,6 +21,7 @@ var (
 	cmd                *cobra.Command
 	flagTFDir          string
 	flagModuleListFile string
+	flagWorkDir        string
 )
 
 func NewCmd() *cobra.Command {
@@ -33,6 +34,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&flagTFDir, "dir", "d", ".", "terraform directory path")
 	cmd.Flags().StringVarP(&flagModuleListFile, "module-list-file", "f", "", "list file of modules to process")
+	cmd.Flags().StringVarP(&flagWorkDir, "workdir", "w", "", "store all module sources in this directory; improves performance by reusing data between harvest commands")
 
 	return cmd
 }
@@ -56,7 +58,7 @@ func cmdRunE(cmd *cobra.Command, _ []string) error {
 
 	tfRunner := runner.NewTerraformRunner()
 	for _, item := range moduleList.Farm {
-		dir, _, err := item.CreateTerraformFile()
+		dir, _, err := item.CreateTerraformFile(flagWorkDir)
 		if err != nil {
 			return err
 		}

--- a/src/cli/cmd/harvest/modules/cmd.go
+++ b/src/cli/cmd/harvest/modules/cmd.go
@@ -25,6 +25,7 @@ var (
 	flagTFDir          string
 	flagIncludeLocal   bool
 	flagModuleListFile string
+	flagWorkDir        string
 )
 
 func NewCmd() *cobra.Command {
@@ -43,6 +44,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&flagTFDir, "dir", "d", ".", "terraform directory path")
 	cmd.Flags().BoolVarP(&flagIncludeLocal, "enable-local-modules", "l", false, "A boolean flag to control include/exclude of local modules")
 	cmd.Flags().StringVarP(&flagModuleListFile, "module-list-file", "f", "", "list file of modules to process")
+	cmd.Flags().StringVarP(&flagWorkDir, "workdir", "w", "", "store all module sources in this directory; improves performance by reusing data between harvest commands")
 
 	return cmd
 }
@@ -67,7 +69,7 @@ func cmdRunE(cmd *cobra.Command, _ []string) error {
 	tfRunner := runner.NewTerraformRunner()
 	for _, item := range moduleList.Farm {
 		if item.Export {
-			dir, _, err := item.CreateTerraformFile()
+			dir, _, err := item.CreateTerraformFile(flagWorkDir)
 			if err != nil {
 				return err
 			}

--- a/src/cli/cmd/harvest/resources/cmd.go
+++ b/src/cli/cmd/harvest/resources/cmd.go
@@ -20,6 +20,7 @@ var (
 
 	flagSchemaFile     string
 	flagModuleListFile string
+	flagWorkDir        string
 )
 
 func NewCmd() *cobra.Command {
@@ -38,6 +39,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&flagSchemaFile, "schema-file", "s", DefaultSchemaPath, "terraform provider schema json file path")
 	cmd.Flags().StringVarP(&flagModuleListFile, "module-list-file", "f", "", "list file of modules to process")
+	cmd.Flags().StringVarP(&flagWorkDir, "workdir", "w", "", "store all module sources in this directory; improves performance by reusing data between harvest commands")
 
 	return cmd
 }
@@ -62,7 +64,7 @@ func cmdRunE(cmd *cobra.Command, _ []string) error {
 
 	tfRunner := runner.NewTerraformRunner()
 	for _, item := range moduleList.Farm {
-		dir, _, err := item.CreateTerraformFile()
+		dir, _, err := item.CreateTerraformFile(flagWorkDir)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/go.mod
+++ b/src/pkg/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.2
 	github.com/go-kit/kit v0.12.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/hashicorp/hcl/v2 v2.17.0
@@ -34,7 +35,6 @@ require (
 )
 
 require (
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect


### PR DESCRIPTION
Add optional --workdir (-w) flag to harvest command. If set, the harvested modules will be placed to this directory instead of a temporary location.
The advantage of using the workdir is that the initialized modules stay together with installed plugins making subsequent runs of other harvest commands significantly faster as the plugins do not need to be installed in 'terraform init'.

By default this is set to "" falling back to a temporary location unique to every run.

Changed the Makefile to use workdir by default set to /tmp/harvest.