### PR TITLE
TER-278 Change doc string format for components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,5 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 RUN rm -rf /go/pkg/mod && mv /go/pkg/mod.bak /go/pkg/mod
 COPY Makefile ./
 COPY examples ./examples
-ENTRYPOINT [ "make", "test" ]
+# -- tells Make that everything after is an argument not an option
+ENTRYPOINT [ "make", "--", "--test" ]

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,8 @@ mod-tidy:  ## run go mod tidy on each workspace entity, and then sync workspace
 	@go mod download && go work sync
 
 .PHONY: test
-test:  ## Run go unit tests
+test: start-db --test ## Run go unit tests
+--test:
 	mkdir -p coverage
 	go test -tags=mock,dbtest -coverprofile $(COVERAGE_FILE) github.com/cldcvr/terrarium/...
 	@echo "-- Test coverage for terrarium --"

--- a/examples/platform/component_postgres.tf
+++ b/examples/platform/component_postgres.tf
@@ -1,4 +1,5 @@
-# component[PostgreSQL Database]: A relational database management system using SQL.
+# A relational database management system using SQL.
+# @title: PostgreSQL Database
 module "tr_component_postgres" {
   source = "terraform-aws-modules/rds/aws"
 

--- a/examples/platform/component_redis.tf
+++ b/examples/platform/component_redis.tf
@@ -1,4 +1,5 @@
-# component[Redis Cache]: An in-memory data structure store used as a cache or message broker.
+# An in-memory data structure store used as a cache or message broker.
+# @title: Redis Cache
 module "tr_component_redis" {
   source = "cloudposse/elasticache-redis/aws"
 

--- a/src/pkg/metadata/platform/components.go
+++ b/src/pkg/metadata/platform/components.go
@@ -4,7 +4,6 @@
 package platform
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"regexp"
@@ -13,16 +12,23 @@ import (
 
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/pkg/jsonschema"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/icza/backscanner"
 	"github.com/xeipuuv/gojsonschema"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
+const (
+	docCommentTitleArgTag = "title"
+	docCommentDescArgTag  = "description"
+)
+
 var (
 	docCommentMatcher    = regexp.MustCompile("^\\s*#.+$")
-	docCommentArgMatcher = regexp.MustCompile("#\\s*(.+?)(\\s*\\[(.+)\\])?:\\s*(.+)")
+	docCommentArgMatcher = regexp.MustCompile("^#\\s*@(.+?)\\s*:\\s*(.+)$")
 )
 
 func NewComponents(platformModule *tfconfig.Module) Components {
@@ -58,19 +64,11 @@ func (cArr *Components) Parse(platformModule *tfconfig.Module) {
 		if c == nil {
 			c = cArr.Append(Component{ID: id})
 		}
-		docs, _, err := parseBlockDocComment(mc.Module, mc.Pos)
-		if err != nil {
-			return
-		}
+		docs := getBlockDoc(mc.Pos)
 
 		c.Title = tfValueToTitle(id, nil) // default to component name in title format
-		if docs, ok := docs["component"]; ok {
-			docTitle := docs[0]
-			if docTitle != "" {
-				c.Title = docTitle
-			}
-			c.Description = docs[1]
-		}
+		setValueFromDocIfFound(&c.Title, docCommentTitleArgTag, docs)
+		setValueFromDocIfFound(&c.Description, docCommentDescArgTag, docs)
 
 		c.fetchInputs(platformModule)
 		c.fetchOutputs(platformModule)
@@ -92,10 +90,7 @@ func (c *Component) fetchInputs(m *tfconfig.Module) {
 		c.Inputs = &jsonschema.Node{}
 	}
 
-	fieldDoc, _, err := parseBlockDocComment(m, v.Pos)
-	if err != nil {
-		return
-	}
+	fieldDoc := getLocalInputBlockDocs(v)
 
 	cv, _ := v.Expression.Value(nil)
 	valMap := cv.AsValueMap()
@@ -104,7 +99,49 @@ func (c *Component) fetchInputs(m *tfconfig.Module) {
 	}
 }
 
-func parseBlockDocComment(m *tfconfig.Module, blockPos tfconfig.SourcePos) (args map[string][2]string, lines []string, err error) {
+func getLocalInputBlockDocs(block *tfconfig.Local) (docsByKey map[string]map[string]string) {
+	docsByKey = make(map[string]map[string]string)
+	switch localExpr := block.Expression.(type) {
+	case *hclsyntax.ObjectConsExpr:
+		for _, kv := range localExpr.ExprMap() { // default input block
+			switch inputExpr := kv.Value.(type) {
+			case *hclsyntax.ObjectConsExpr:
+				for _, input := range inputExpr.ExprMap() { // individual input values
+					inputName, _ := input.Key.Value(nil) // input name value
+					inputRange := input.Key.Range()      // input name start position (i.e. read doc comment from here upwards)
+					docsByKey[inputName.AsString()] = getBlockDoc(tfconfig.SourcePos{
+						Filename:  block.ParentPos.Filename,
+						Line:      inputRange.Start.Line,
+						StartByte: inputRange.Start.Byte,
+						EndLine:   inputRange.End.Line,
+						EndByte:   inputRange.End.Byte,
+					})
+				}
+			}
+		}
+	}
+	return
+}
+
+func getBlockDoc(blockPos tfconfig.SourcePos) (args map[string]string) {
+	head, args, _, _ := parseBlockDocComment(blockPos)
+
+	if _, ok := args[docCommentDescArgTag]; !ok && head != nil { // if there is no description tag use the head lines instead
+		args[docCommentDescArgTag] = strings.Join(head, "\n")
+	}
+
+	return
+}
+
+// parseBlockDocComment parses docummentation comment to sections:
+//
+// # Quo in officia nobis autem pariatur sit tenetur ut dolores.		<--- head line
+// # Deleniti asperiores quaerat.										<--- head line
+// # @title: Incidunt aperiam sit facilis.								<--- argument tag
+// # Voluptatem officiis aperiam.										<--- reminder
+//
+// It returns head (lines before the first argument tag with comment symbol removed), args (argument tags grouped by tag name), lines (list of all lines).
+func parseBlockDocComment(blockPos tfconfig.SourcePos) (head []string, args map[string]string, lines []string, err error) {
 	if blockPos.Filename == "" {
 		return
 	}
@@ -112,13 +149,19 @@ func parseBlockDocComment(m *tfconfig.Module, blockPos tfconfig.SourcePos) (args
 	if err != nil {
 		return
 	}
+	slices.Reverse(lines) // lines are read bottom-up
 
-	args = make(map[string][2]string, len(lines))
+	head = make([]string, 0, len(lines))
+	args = make(map[string]string, len(lines))
 	for _, line := range lines {
 		if groups := docCommentArgMatcher.FindStringSubmatch(line); groups != nil {
-			args[groups[1]] = [2]string{groups[3], groups[4]}
+			args[groups[1]] = groups[2]
+		}
+		if len(args) < 1 { // all lines before the first argument tag form the comment head
+			head = append(head, strings.TrimSpace(strings.TrimPrefix(line, "#")))
 		}
 	}
+
 	return
 }
 
@@ -189,14 +232,17 @@ func tfValueToTitle(value string, prefix *string) string {
 	return cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(strings.TrimPrefix(value, *prefix), "_", " "))
 }
 
-func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName string, fieldDoc map[string][2]string) {
+func setValueFromDocIfFound(value *string, valueTagName string, fieldDoc map[string]string) {
+	if newValue, ok := fieldDoc[valueTagName]; ok && newValue != "" {
+		*value = newValue
+	}
+}
+
+func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName string, fieldDocs map[string]map[string]string) {
 	existingSchema.Title = tfValueToTitle(fieldName, nil) // default to field name in title format
-	if docString, ok := fieldDoc[fieldName]; ok {
-		docTitle := docString[0]
-		if docTitle != "" {
-			existingSchema.Title = docTitle
-		}
-		existingSchema.Description = docString[1]
+	if fieldDoc, ok := fieldDocs[fieldName]; ok {
+		setValueFromDocIfFound(&existingSchema.Title, docCommentTitleArgTag, fieldDoc)
+		setValueFromDocIfFound(&existingSchema.Description, docCommentDescArgTag, fieldDoc)
 	}
 
 	switch value.Type().FriendlyName() {
@@ -210,8 +256,7 @@ func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName s
 
 		for key, val := range mapValue {
 			existingSchema.Properties[key] = &jsonschema.Node{}
-			valueFieldName := strings.TrimPrefix(fmt.Sprintf("%s.%s", fieldName, key), ".")
-			extractSchema(existingSchema.Properties[key], val, valueFieldName, fieldDoc)
+			extractSchema(existingSchema.Properties[key], val, key, fieldDocs)
 		}
 	case "string":
 		existingSchema.Type = gojsonschema.TYPE_STRING
@@ -233,7 +278,7 @@ func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName s
 		}
 
 		if len(listVal) > 0 {
-			extractSchema(existingSchema.Items, listVal[0], fieldName, fieldDoc)
+			extractSchema(existingSchema.Items, listVal[0], fieldName, fieldDocs)
 		}
 	}
 }

--- a/src/pkg/metadata/platform/test-component/main.tf
+++ b/src/pkg/metadata/platform/test-component/main.tf
@@ -15,7 +15,15 @@ locals {
   tr_component_redis = {
     "default" : {
       # Version of the Redis engine to use
+      # @description: Redis description override
       "version" : "5.0.6"
     }
   }
+}
+
+# A relational database management system using SQL.
+# @title: PostgreSQL Database
+# Dolores fugiat dolor illo omnis optio ipsam.
+module "tr_component_postgres" {
+  source = "terraform-aws-modules/rds/aws"
 }


### PR DESCRIPTION
Use the comment above the field or component as description. Support @title (display name) and @description (override the description) tags.

For component:
```
# A relational database management system using SQL.
# @title: PostgreSQL Database
module "tr_component_postgres" {}
```

For inputs:
```
tr_component_postgres = {
    "default" : {
      # Version of the PostgreSQL engine to use
      "version" : "11",
      # The name provided here may get prefix and suffix based
      # @title: Database Name
      "db_name" : "default_db"
    }
  }
```