### PR TITLE
TER-283 Fix cross-platform release build for CGO

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,38 +1,33 @@
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+    - 'v0.*'
 
 permissions:
     contents: write
     packages: write
 
 jobs:
-  releases-matrix:
-    name: Release Go Binary
+  build-and-release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        exclude:
-          - goarch: arm64
-            goos: windows
     steps:
-    - uses: actions/checkout@v3
-    - name: Set env vars
-      run: |
-        {
-          echo "BUILD_DATE=$(date -u +%Y%m%d)"
-        } >> ${GITHUB_ENV}
-    - uses: wangyoucao577/go-release-action@v1.40
-      with:
-        github_token: ${{ secrets.GH_RELEASE_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: "1.20"
-        pre_command: "export CGO_ENABLED=1"
-        project_path: "./src/cli/terrarium"
-        binary_name: "terrarium"
-        ldflags: "-s -w -X 'github.com/cldcvr/terrarium/src/cli/internal/build.Version=${{ github.ref_name }}' -X 'github.com/cldcvr/terrarium/src/cli/internal/build.Date=${{ env.BUILD_DATE }}'"
-        overwrite: true
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Install xgo
+        run: |
+          go install src.techknowlogick.com/xgo@latest
+      - name: Create release artifacts
+        run: |
+          ./scripts/create-release-artifacts.sh ${{ github.ref_name }}
+      - name: Create release and upload artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
+          generate_release_notes: true
+          files: |
+            ./.bin/terrarium-${{ github.ref_name }}-*.tar.gz
+            ./.bin/terrarium-${{ github.ref_name }}-*.zip
+

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,6 @@ BUILD_DATE=$(shell date "+%Y-%m-%d")
 BUILD_DIR=.bin
 CLI_NAME = terrarium
 BINARY_NAME = $(BUILD_DIR)/$(CLI_NAME)
-BINARY_NAME_WIN = $(BUILD_DIR)/win/$(CLI_NAME).exe
-BINARY_NAME_LINUX = $(BUILD_DIR)/linux/$(CLI_NAME)
-BINARY_NAME_MACOS_ARM = $(BUILD_DIR)/macos/arm64/$(CLI_NAME)
-BINARY_NAME_MACOS_I386 = $(BUILD_DIR)/macos/i386/$(CLI_NAME)
 
 ifeq (${TAG},)
 	TAG=$(shell git describe --exact-match --tags 2> /dev/null)
@@ -130,29 +126,6 @@ $(BINARY_NAME): $(CLI_SRCS)
 	$(call make_binary, $(BINARY_NAME),$(shell go env GOOS),$(shell go env GOARCH))
 .PHONY: binary
 binary: $(BINARY_NAME)  ## Build application binary (native)
-
-$(BINARY_NAME_WIN): $(CLI_SRCS)
-	$(call make_binary,$@,windows,amd64)
-.PHONY: binary_win
-binary_win: $(BINARY_NAME_WIN)  ## Build application binary for Windows
-
-$(BINARY_NAME_LINUX): $(CLI_SRCS)
-	$(call make_binary,$@,linux,amd64)
-.PHONY: binary_linux
-binary_linux: $(BINARY_NAME_LINUX)  ## Build application binary for Linux
-
-$(BINARY_NAME_MACOS_ARM): $(CLI_SRCS)
-	$(call make_binary,$@,darwin,arm64)
-$(BINARY_NAME_MACOS_I386): $(CLI_SRCS)
-	$(call make_binary,$@,darwin,amd64)
-.PHONY: binary_macos
-binary_macos: $(BINARY_NAME_MACOS_ARM) $(BINARY_NAME_MACOS_I386)  ## Build application binaries for MacOS
-
-$(ZIP_FILE): $(BINARY_NAME_WIN) $(BINARY_NAME_LINUX) binary_macos
-	cd $(BUILD_DIR); \
-	zip -r ../$(ZIP_FILE) *
-.PHONY: binaries
-binaries: $(ZIP_FILE)  ## Build binary for each supported platform and archive to zip
 
 .PHONY: install
 install:  ## Install the CLI native binary into GOBIN

--- a/scripts/create-release-artifacts.sh
+++ b/scripts/create-release-artifacts.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) CloudCover
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+VERSION=$1
+
+CLI_NAME=terrarium
+BUILD_DATE=$(date "+%Y-%m-%d")
+BUILD_DIR=$(pwd)/.bin
+XGO_GO_VERSION="go-1.20.x"
+XGO_TARGETS="darwin/amd64,linux/amd64,darwin/arm64,linux/arm64,windows/amd64"
+GZIP_TARGETS_IN=("darwin-10.12-amd64" "darwin-10.12-arm64" "linux-amd64" "linux-arm64")
+GZIP_TARGETS_OUT=("macos-amd64" "macos-arm64" "linux-amd64" "linux-arm64")
+ZIP_TARGETS_IN=("windows-4.0-amd64")
+ZIP_TARGETS_OUT=("windows-amd64")
+
+GO_LDFLAGS="-s -w -X github.com/cldcvr/terrarium/src/cli/internal/build.Version=${VERSION} -X github.com/cldcvr/terrarium/src/cli/internal/build.Date=${BUILD_DATE}"
+
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+xgo -out ${CLI_NAME}-${VERSION} \
+ 	-go ${XGO_GO_VERSION}  \
+ 	--targets=${XGO_TARGETS} \
+ 	-ldflags="${GO_LDFLAGS}" \
+ 	github.com/cldcvr/terrarium/src/cli/terrarium
+
+for i in ${!GZIP_TARGETS_IN[@]}; do
+    mv ${CLI_NAME}-${VERSION}-${GZIP_TARGETS_IN[$i]} ${CLI_NAME}
+    tar -czvf ${CLI_NAME}-${VERSION}-${GZIP_TARGETS_OUT[$i]}.tar.gz ${CLI_NAME}
+done
+rm ${CLI_NAME}
+
+for i in ${!ZIP_TARGETS_IN[@]}; do
+    mv ${CLI_NAME}-${VERSION}-${ZIP_TARGETS_IN[$i]}.exe ${CLI_NAME}.exe
+    zip -r ${CLI_NAME}-${VERSION}-${ZIP_TARGETS_OUT[$i]}.zip ${CLI_NAME}.exe
+done
+rm ${CLI_NAME}.exe
+
+


### PR DESCRIPTION
The root issue here is that once we switche to CGO_ENABLED=1, the
cross compile across OS/Arch became significantly more complex.
In order to accomplish this, much more build infrastructure has to
be in place - especially on Linux which is what we use for our
build pipelines.

This implements the cross-platform build using a tool called xgo.
This tool was built specifically to solve this problem. I intended
to integrate this more directly into the project Make setup but this
was proving to add even more complexity. As such, it is run from a
bash script - create-release-artifact.sh. The script uses xgo to
create the relevant binaries and packages them up as individual tar.gz
(or zip).

This also includes adjustments to the Github action release.yml to
call the script to generate the release artifacts, create a Github
release and then upload all the artifacts. Note: this is change to
the current action where the release is created manually and the
pipeline is triggered. Here a tag is pushed which kicks off the
release process.

Given these changes, the cross-compile builds in the existing
Makefile have been removed as they aren't relevant/functional
anymore.
