### PR TITLE
TER-251 Add profile metadata

### DIFF
--- a/examples/platform/dev.tfvars
+++ b/examples/platform/dev.tfvars
@@ -1,1 +1,3 @@
-all_db_instance_class="t2.nano"
+# Infrastructure configuration optimized for development deployment.
+# @title: Development Configuration
+all_db_instance_class = "t2.nano"

--- a/examples/platform/prod.tfvars
+++ b/examples/platform/prod.tfvars
@@ -1,1 +1,3 @@
-all_db_instance_class="t2.large"
+# Infrastructure configuration optimized for production deployment.
+# @title: Production Configuration
+all_db_instance_class = "t2.large"

--- a/src/cli/cmd/platform/lint/testdata/valid-terraform-1/terrarium.yaml
+++ b/src/cli/cmd/platform/lint/testdata/valid-terraform-1/terrarium.yaml
@@ -1,3 +1,4 @@
+profiles: []
 components:
     - id: postgres
       title: PostgreSQL Database

--- a/src/pkg/metadata/platform/comments.go
+++ b/src/pkg/metadata/platform/comments.go
@@ -1,0 +1,172 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package platform
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/icza/backscanner"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	docCommentTitleArgTag = "title"
+	docCommentDescArgTag  = "description"
+	docCommentEnumArgTag  = "enum"
+)
+
+func SetListFromDocIfFound(values *[]interface{}, valueTagName string, fieldDoc map[string]string) {
+	var enumCSV string
+	if ok := SetValueFromDocIfFound(&enumCSV, valueTagName, fieldDoc); ok {
+		enumValues := strings.Split(enumCSV, ",")
+		*values = make([]interface{}, 0, len(enumValues))
+		for _, value := range enumValues {
+			*values = append(*values, strings.TrimSpace(value))
+		}
+	}
+}
+
+func SetValueFromDocIfFound(value *string, valueTagName string, fieldDoc map[string]string) (ok bool) {
+	if newValue, exists := fieldDoc[valueTagName]; exists && newValue != "" {
+		*value = newValue
+		ok = true
+	}
+	return
+}
+
+// GetDoc reads a given file and returns documentation
+// when reverse is false the file is read from the beginning until the end byte position or the EOF (endBytePos < 0 reads the entire file)
+// when reverse is true the file is read from the end byte position to the beginning.
+func GetDoc(filename string, endBytePos int, reverse bool) (args map[string]string, err error) {
+	head, args, _, err := parseCommentLines(filename, endBytePos, reverse)
+	if err != nil {
+		return
+	}
+
+	if _, ok := args[docCommentDescArgTag]; !ok && head != nil { // if there is no description tag use the head lines instead
+		args[docCommentDescArgTag] = strings.Join(head, "\n")
+	}
+
+	return
+}
+
+// parseCommentLines parses docummentation comment to sections:
+//
+// # Quo in officia nobis autem pariatur sit tenetur ut dolores.		<--- head line
+// # Deleniti asperiores quaerat.										<--- head line
+// # @title: Incidunt aperiam sit facilis.								<--- argument tag
+// # Voluptatem officiis aperiam.										<--- reminder
+//
+// It returns head (lines before the first argument tag with comment symbol removed), args (argument tags grouped by tag name), lines (list of all lines).
+func parseCommentLines(filename string, endBytePos int, reverse bool) (head []string, args map[string]string, lines []string, err error) {
+	if filename == "" {
+		return
+	}
+	lines, err = readCommentLines(filename, endBytePos, reverse)
+	if err != nil {
+		return
+	}
+
+	head = make([]string, 0, len(lines))
+	args = make(map[string]string, len(lines))
+	for _, line := range lines {
+		if groups := docCommentArgMatcher.FindStringSubmatch(line); groups != nil {
+			args[groups[1]] = groups[2]
+		}
+		if len(args) < 1 { // all lines before the first argument tag form the comment head
+			head = append(head, strings.TrimSpace(strings.TrimPrefix(line, "#")))
+		}
+	}
+
+	return
+}
+
+// read all comment lines above a given end byte until the first non-comment or the end of file
+func readCommentLines(filename string, endBytePos int, reverse bool) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	lines := make([]string, 0)
+	reader := NewLineReader(file, endBytePos, reverse)
+	if err := reader.Read(&lines); err != nil {
+		return lines, err
+	}
+
+	comments := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" && len(comments) < 1 {
+			continue // ignore empty lines until the first comment above the end position
+		} else if docCommentMatcher.MatchString(trimmedLine) {
+			comments = append(comments, trimmedLine)
+			continue
+		}
+		break
+	}
+
+	if reverse {
+		slices.Reverse(comments) // lines are read bottom-up
+	}
+	return comments, nil
+}
+
+type LineReader interface {
+	Read(lines *[]string) (err error)
+}
+
+func NewLineReader(fp *os.File, endBytePos int, reverse bool) LineReader {
+	if reverse {
+		return &backwardReader{
+			reader:     fp,
+			endBytePos: endBytePos,
+		}
+	}
+	return &forwardReader{
+		reader:     fp,
+		endBytePos: int64(endBytePos),
+	}
+}
+
+type forwardReader struct {
+	reader     *os.File
+	endBytePos int64
+}
+
+func (r *forwardReader) Read(lines *[]string) (err error) {
+	var reader io.Reader = r.reader
+	if r.endBytePos >= 0 {
+		reader = io.LimitReader(r.reader, r.endBytePos)
+	}
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		*lines = append(*lines, scanner.Text())
+	}
+	return scanner.Err()
+}
+
+type backwardReader struct {
+	reader     *os.File
+	endBytePos int
+}
+
+func (r *backwardReader) Read(lines *[]string) (err error) {
+	scanner := backscanner.New(r.reader, r.endBytePos)
+	for {
+		line, _, err := scanner.Line()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		*lines = append(*lines, line)
+	}
+
+	return nil
+}

--- a/src/pkg/metadata/platform/comments_test.go
+++ b/src/pkg/metadata/platform/comments_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDoc(t *testing.T) {
+	type args struct {
+		filename   string
+		endBytePos int
+		reverse    bool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantArgs map[string]string
+		wantErr  bool
+	}{
+		{
+			name: "read forward N bytes",
+			args: args{
+				filename:   "./test-component/main.tf",
+				endBytePos: 10,
+				reverse:    false,
+			},
+			wantArgs: map[string]string{
+				"description": "Auto-gen",
+			},
+		},
+		{
+			name: "read forward until EOF",
+			args: args{
+				filename:   "./test-component/main.tf",
+				endBytePos: -1,
+				reverse:    false,
+			},
+			wantArgs: map[string]string{
+				"description": "Auto-generated component input definitions.",
+				"title":       "Component Inputs",
+			},
+		},
+		{
+			name: "read backward",
+			args: args{
+				filename:   "./test-component/main.tf",
+				endBytePos: 340,
+				reverse:    true,
+			},
+			wantArgs: map[string]string{
+				"description": "Version of the PostgreSQL engine to use",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotArgs, gotErr := GetDoc(tt.args.filename, tt.args.endBytePos, tt.args.reverse)
+			if tt.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.NoError(t, gotErr)
+				assert.Equal(t, tt.wantArgs, gotArgs)
+			}
+		})
+	}
+}
+
+func TestSetValueFromDocIfFound(t *testing.T) {
+	type args struct {
+		value        *string
+		valueTagName string
+		fieldDoc     map[string]string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantValue string
+	}{
+		{
+			name: "tag found",
+			args: args{
+				value:        new(string),
+				valueTagName: "moratorium",
+				fieldDoc: map[string]string{
+					"moratorium": "withdrawal turquoise Incredible",
+				},
+			},
+			wantValue: "withdrawal turquoise Incredible",
+		},
+		{
+			name: "tag not found",
+			args: args{
+				value:        new(string),
+				valueTagName: "optimize",
+				fieldDoc: map[string]string{
+					"moratorium": "withdrawal turquoise Incredible",
+				},
+			},
+			wantValue: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetValueFromDocIfFound(tt.args.value, tt.args.valueTagName, tt.args.fieldDoc)
+			assert.Equal(t, tt.wantValue, *tt.args.value)
+		})
+	}
+}

--- a/src/pkg/metadata/platform/components.go
+++ b/src/pkg/metadata/platform/components.go
@@ -4,8 +4,6 @@
 package platform
 
 import (
-	"io"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -13,18 +11,10 @@ import (
 	"github.com/cldcvr/terraform-config-inspect/tfconfig"
 	"github.com/cldcvr/terrarium/src/pkg/jsonschema"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/icza/backscanner"
 	"github.com/xeipuuv/gojsonschema"
 	"github.com/zclconf/go-cty/cty"
-	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-)
-
-const (
-	docCommentTitleArgTag = "title"
-	docCommentDescArgTag  = "description"
-	docCommentEnumArgTag  = "enum"
 )
 
 var (
@@ -68,8 +58,8 @@ func (cArr *Components) Parse(platformModule *tfconfig.Module) {
 		docs := getBlockDoc(mc.Pos)
 
 		c.Title = tfValueToTitle(id, nil) // default to component name in title format
-		setValueFromDocIfFound(&c.Title, docCommentTitleArgTag, docs)
-		setValueFromDocIfFound(&c.Description, docCommentDescArgTag, docs)
+		SetValueFromDocIfFound(&c.Title, docCommentTitleArgTag, docs)
+		SetValueFromDocIfFound(&c.Description, docCommentDescArgTag, docs)
 
 		c.fetchInputs(platformModule)
 		c.fetchOutputs(platformModule)
@@ -125,75 +115,8 @@ func getLocalInputBlockDocs(block *tfconfig.Local) (docsByKey map[string]map[str
 }
 
 func getBlockDoc(blockPos tfconfig.SourcePos) (args map[string]string) {
-	head, args, _, _ := parseBlockDocComment(blockPos)
-
-	if _, ok := args[docCommentDescArgTag]; !ok && head != nil { // if there is no description tag use the head lines instead
-		args[docCommentDescArgTag] = strings.Join(head, "\n")
-	}
-
+	args, _ = GetDoc(blockPos.Filename, blockPos.StartByte, true)
 	return
-}
-
-// parseBlockDocComment parses docummentation comment to sections:
-//
-// # Quo in officia nobis autem pariatur sit tenetur ut dolores.		<--- head line
-// # Deleniti asperiores quaerat.										<--- head line
-// # @title: Incidunt aperiam sit facilis.								<--- argument tag
-// # Voluptatem officiis aperiam.										<--- reminder
-//
-// It returns head (lines before the first argument tag with comment symbol removed), args (argument tags grouped by tag name), lines (list of all lines).
-func parseBlockDocComment(blockPos tfconfig.SourcePos) (head []string, args map[string]string, lines []string, err error) {
-	if blockPos.Filename == "" {
-		return
-	}
-	lines, err = readCommentLinesAbove(blockPos.Filename, blockPos.StartByte)
-	if err != nil {
-		return
-	}
-	slices.Reverse(lines) // lines are read bottom-up
-
-	head = make([]string, 0, len(lines))
-	args = make(map[string]string, len(lines))
-	for _, line := range lines {
-		if groups := docCommentArgMatcher.FindStringSubmatch(line); groups != nil {
-			args[groups[1]] = groups[2]
-		}
-		if len(args) < 1 { // all lines before the first argument tag form the comment head
-			head = append(head, strings.TrimSpace(strings.TrimPrefix(line, "#")))
-		}
-	}
-
-	return
-}
-
-// read all comment lines (ignoring empty lines) above a given end byte until the first non-comment or the end of file
-func readCommentLinesAbove(filename string, endPos int) ([]string, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var lines []string
-	scanner := backscanner.New(file, endPos)
-	for {
-		line, _, err := scanner.Line()
-		if err == io.EOF {
-			return lines, nil
-		} else if err != nil {
-			return lines, err
-		}
-
-		trimmedLine := strings.TrimSpace(line)
-		if trimmedLine == "" {
-			continue
-		} else if docCommentMatcher.MatchString(trimmedLine) {
-			lines = append(lines, trimmedLine)
-			continue
-		}
-
-		return lines, nil
-	}
 }
 
 func (c *Component) fetchOutputs(m *tfconfig.Module) {
@@ -233,31 +156,12 @@ func tfValueToTitle(value string, prefix *string) string {
 	return cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(strings.TrimPrefix(value, *prefix), "_", " "))
 }
 
-func setListFromDocIfFound(values *[]interface{}, valueTagName string, fieldDoc map[string]string) {
-	var enumCSV string
-	if ok := setValueFromDocIfFound(&enumCSV, valueTagName, fieldDoc); ok {
-		enumValues := strings.Split(enumCSV, ",")
-		*values = make([]interface{}, 0, len(enumValues))
-		for _, value := range enumValues {
-			*values = append(*values, strings.TrimSpace(value))
-		}
-	}
-}
-
-func setValueFromDocIfFound(value *string, valueTagName string, fieldDoc map[string]string) (ok bool) {
-	if newValue, exists := fieldDoc[valueTagName]; exists && newValue != "" {
-		*value = newValue
-		ok = true
-	}
-	return
-}
-
 func extractSchema(existingSchema *jsonschema.Node, value cty.Value, fieldName string, fieldDocs map[string]map[string]string) {
 	existingSchema.Title = tfValueToTitle(fieldName, nil) // default to field name in title format
 	if fieldDoc, ok := fieldDocs[fieldName]; ok {
-		setValueFromDocIfFound(&existingSchema.Title, docCommentTitleArgTag, fieldDoc)
-		setValueFromDocIfFound(&existingSchema.Description, docCommentDescArgTag, fieldDoc)
-		setListFromDocIfFound(&existingSchema.Enum, docCommentEnumArgTag, fieldDoc)
+		SetValueFromDocIfFound(&existingSchema.Title, docCommentTitleArgTag, fieldDoc)
+		SetValueFromDocIfFound(&existingSchema.Description, docCommentDescArgTag, fieldDoc)
+		SetListFromDocIfFound(&existingSchema.Enum, docCommentEnumArgTag, fieldDoc)
 	}
 
 	switch value.Type().FriendlyName() {

--- a/src/pkg/metadata/platform/model.go
+++ b/src/pkg/metadata/platform/model.go
@@ -14,6 +14,16 @@ const (
 	ComponentPrefix    = "tr_component_" // Prefix for component identifiers in terraform code
 )
 
+// Profile represents a set of pre-set configuration variables that can be applied to generated Terraform code.
+type Profile struct {
+	ID          string `yaml:",omitempty"` // Unique identifier for the profile
+	Title       string `yaml:",omitempty"` // Descriptive title for the profile
+	Description string `yaml:",omitempty"` // Detailed description of the profile's properties
+}
+
+// Profiles is a slice of Profile objects.
+type Profiles []Profile
+
 // Component represents an implementation of a dependency in the Terrarium platform.
 type Component struct {
 	ID          string           `yaml:",omitempty"` // Unique identifier for the component
@@ -29,6 +39,7 @@ type Components []Component
 // PlatformMetadata represents the metadata for the Terrarium platform.
 // It includes the components and the graph that defines the relationships between terraform blocks.
 type PlatformMetadata struct {
+	Profiles   Profiles   // Configuration profiles in the platform
 	Components Components // Components in the Terrarium platform
 	Graph      Graph      // Graph defining the relationships between terraform blocks
 }
@@ -92,5 +103,6 @@ func NewPlatformMetadata(platformModule *tfconfig.Module, existingYaml []byte) (
 	// Parse the platform module to create the components and the graph
 	p.Components.Parse(platformModule)
 	p.Graph.Parse(platformModule)
+	p.Profiles.Parse(platformModule)
 	return &p, nil
 }

--- a/src/pkg/metadata/platform/profiles.go
+++ b/src/pkg/metadata/platform/profiles.go
@@ -1,0 +1,51 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package platform
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/cldcvr/terraform-config-inspect/tfconfig"
+)
+
+const (
+	profileFileSuffix = ".tfvars"
+)
+
+func (pArr *Profiles) Parse(platformModule *tfconfig.Module) {
+	if list, err := os.ReadDir(platformModule.Path); err == nil {
+		for _, item := range list {
+			if item.Type().IsRegular() {
+				if baseName, found := strings.CutSuffix(item.Name(), profileFileSuffix); found {
+					p := pArr.GetByID(baseName)
+					if p == nil {
+						p = pArr.Append(Profile{ID: baseName})
+					}
+
+					if doc, err := GetDoc(path.Join(platformModule.Path, item.Name()), -1, false); err == nil {
+						SetValueFromDocIfFound(&p.Title, docCommentTitleArgTag, doc)
+						SetValueFromDocIfFound(&p.Description, docCommentDescArgTag, doc)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (pArr Profiles) GetByID(id string) *Profile {
+	for i, v := range pArr {
+		if v.ID == id {
+			return &pArr[i]
+		}
+	}
+
+	return nil
+}
+
+func (pArr *Profiles) Append(p Profile) *Profile {
+	(*pArr) = append((*pArr), p)
+	return &(*pArr)[len(*pArr)-1]
+}

--- a/src/pkg/metadata/platform/profiles_test.go
+++ b/src/pkg/metadata/platform/profiles_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) CloudCover
+// SPDX-License-Identifier: Apache-2.0
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/cldcvr/terraform-config-inspect/tfconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfiles_Parse(t *testing.T) {
+	type args struct {
+		platformModule *tfconfig.Module
+	}
+	tests := []struct {
+		name              string
+		initialCollection *Profiles
+		args              args
+		wantProfiles      Profiles
+	}{
+		{
+			name:              "load to empty collection",
+			initialCollection: &Profiles{},
+			args: args{
+				platformModule: &tfconfig.Module{
+					Path: "./test-component",
+				},
+			},
+			wantProfiles: Profiles{
+				Profile{
+					ID:          "dev",
+					Title:       "development profile",
+					Description: "Development configuration profile.",
+				},
+				Profile{
+					ID:          "prod",
+					Title:       "",
+					Description: "",
+				},
+			},
+		},
+		{
+			name: "load to existing collection",
+			initialCollection: &Profiles{
+				Profile{
+					ID:          "dev",
+					Title:       "",
+					Description: "",
+				},
+				Profile{
+					ID:          "prod",
+					Title:       "",
+					Description: "",
+				},
+			},
+			args: args{
+				platformModule: &tfconfig.Module{
+					Path: "./test-component",
+				},
+			},
+			wantProfiles: Profiles{
+				Profile{
+					ID:          "dev",
+					Title:       "development profile",
+					Description: "Development configuration profile.",
+				},
+				Profile{
+					ID:          "prod",
+					Title:       "",
+					Description: "",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initialCollection.Parse(tt.args.platformModule)
+			assert.ElementsMatch(t, tt.wantProfiles, *tt.initialCollection)
+		})
+	}
+}

--- a/src/pkg/metadata/platform/test-component/dev.tfvars
+++ b/src/pkg/metadata/platform/test-component/dev.tfvars
@@ -1,0 +1,2 @@
+# Development configuration profile.
+# @title: development profile

--- a/src/pkg/metadata/platform/test-component/main.tf
+++ b/src/pkg/metadata/platform/test-component/main.tf
@@ -1,3 +1,7 @@
+# Auto-generated component input definitions.
+# @title: Component Inputs
+
+# @description: <this should not affect the module description above because there is an empty line between>
 locals {
 
   # Inputs for 'postgres' component instances.

--- a/src/pkg/metadata/platform/test-data.yaml
+++ b/src/pkg/metadata/platform/test-data.yaml
@@ -1,6 +1,12 @@
 # Copyright (c) CloudCover
 # SPDX-License-Identifier: Apache-2.0
-
+profiles:
+  - id: dev
+    description: Infrastructure configuration optimized for development deployment.
+    title: Development Configuration
+  - id: prod
+    description: Infrastructure configuration optimized for production deployment.
+    title: Production Configuration
 components:
   - id: postgres
     title: PostgreSQL Database


### PR DESCRIPTION
Each profile (*.tfvars) file may begin with a standard doc comment...

```
  # Infrastructure configuration optimized for production deployment.
  # @title: Production Configuration
```

...which gets translated to terrarium.yaml section such as...

```
profiles:
  - id: dev
    description: Infrastructure configuration optimized for development deployment.
    title: Development Configuration
  - id: prod
    description: Infrastructure configuration optimized for production deployment.
    title: Production Configuration
```

...where the ID maps to profile name (i.e. dev.tfvars -> dev).

The comment parser was moved to a separate file.
It now supports reading a given file forward and backward.