### PR TITLE
TER-332 remove api image build & push step

### DIFF
--- a/.github/workflows/build-n-push.yaml
+++ b/.github/workflows/build-n-push.yaml
@@ -20,15 +20,6 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Push terrarium-api
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          target: api-runner
-          tags: |
-            cldcvr/terrarium-api:latest,
-            cldcvr/terrarium-api:${{ github.sha }}
-
       - name: Docker Push terrarium-farm-harvester
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
This is already done in Code Pipes app integration pipeline that is triggered automatically on merge to master and then it triggers staging deployment as well automatically.
Therefore, this change removes the redundant GutHub action build & push step for the T8-API image.
