### PR TITLE
TER-334 changing the table settings to wrap the text

### DIFF
--- a/src/cli/internal/utils/output.go
+++ b/src/cli/internal/utils/output.go
@@ -16,7 +16,7 @@ import (
 // OutFormatForList This configures the table format for the List commands
 func OutFormatForList(out io.Writer) *tablewriter.Table {
 	table := tablewriter.NewWriter(out)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 	table.SetAutoFormatHeaders(true)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)


### PR DESCRIPTION
Making the SetAutoWrapText to true, to wrap the table content. Since the dependencies table has big values it can be unreadable to users if not properly wrapped