### PR TITLE
TER-266 Consider AppDependencies with empty inputs equivalent

### DIFF
--- a/src/pkg/metadata/app/model.go
+++ b/src/pkg/metadata/app/model.go
@@ -205,7 +205,16 @@ func (e Dependency) IsEquivalent(other Dependency) bool {
 	return e.ID == other.ID &&
 		e.Use == other.Use &&
 		e.NoProvision == other.NoProvision &&
-		reflect.DeepEqual(e.Inputs, other.Inputs)
+		isEquivalent(e.Inputs, other.Inputs)
+}
+
+func isEquivalent(m map[string]interface{}, n map[string]interface{}) bool {
+	// empty and nil maps are considered equivalent
+	return (isEmpty(m) && isEmpty(n)) || reflect.DeepEqual(m, n)
+}
+
+func isEmpty(m map[string]interface{}) bool {
+	return len(m) == 0
 }
 
 func NewApp(content []byte) (*App, error) {

--- a/src/pkg/metadata/app/model_test.go
+++ b/src/pkg/metadata/app/model_test.go
@@ -115,6 +115,32 @@ func TestDependency_IsEquivalent(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "same with nil input map",
+			base: Dependency{
+				ID:        "eda5d4e1-98bd-438b-b477-c05d32cf79ea",
+				Use:       "Security",
+				EnvPrefix: "strategic",
+				Inputs:    map[string]interface{}{},
+				Outputs: map[string]string{
+					"withdrawal": "compressing",
+				},
+				NoProvision: true,
+			},
+			args: args{
+				other: Dependency{
+					ID:        "eda5d4e1-98bd-438b-b477-c05d32cf79ea",
+					Use:       "Security",
+					EnvPrefix: "strategic",
+					Inputs:    nil,
+					Outputs: map[string]string{
+						"withdrawal": "compressing",
+					},
+					NoProvision: true,
+				},
+			},
+			want: true,
+		},
+		{
 			name: "different id",
 			base: base,
 			args: args{


### PR DESCRIPTION
If Dependency inputs are empty or nill they should be considered equivalent.